### PR TITLE
[MRG] wrong use of Parallel

### DIFF
--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -1734,17 +1734,11 @@ def do_subjects_preproc(subject_factory,
                      "last_stage"]:
             preproc_params[item] = False
 
-    if n_jobs > 1:
-        preproc_subject_data = Parallel(n_jobs=n_jobs)(
-            delayed(do_subject_preproc)(
-                subject_data,
-                **preproc_params
-                ) for subject_data in subjects)
-
-    else:
-        preproc_subject_data = [do_subject_preproc(subject_data,
-                                                   **preproc_params)
-                                for subject_data in subjects]
+    preproc_subject_data = Parallel(n_jobs=n_jobs)(
+        delayed(do_subject_preproc)(
+            subject_data,
+            **preproc_params)
+        for subject_data in subjects)
 
     # DARTEL
     if dartel:


### PR DESCRIPTION
Parallel was used only if n_jobs > 1 which is:
- not useful because Parallel already runs sequentially the jobs if n_jobs=1 (with no Job Pools involved)
- just wrong because n_jobs=-1 for example would also the jobs sequentially
