### PR TITLE
[MRG] Nistats integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ virtualenv:
 
 before_install:
     - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-    - sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-sympy python-networkx python-nipy python-nipype
+    - sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn python-pandas python-networkx python-nipype
     - sudo apt-get install -qq python-pip
     - pip install "nilearn>=0.1.3"
     - pip install coverage coveralls

--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,11 @@ dependencies:
     # Installing SPM
     - source continuous_integration/setup_spm.sh
     # Installing Pypreprocess dependencies
-    - sudo apt-get install -qq python-scipy python-nose python-sklearn python-networkx
+    - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+    - sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn
     - pip install --upgrade pip
     - pip install --upgrade nibabel
-    - pip install sympy nipy nipype nilearn
+    - pip install pandas nipype nilearn
 
   override:
     # Installing pypreprocess

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     - source continuous_integration/setup_spm.sh
     # Installing Pypreprocess dependencies
     - pip install --upgrade pip
-    - pip install scipy sklearn nibabel configobj nose 
+    - pip install scipy sklearn nibabel configobj nose coverage 
     - pip install matplotlib pandas nipype nilearn
 
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -33,9 +33,10 @@ test:
     - cd examples/easy_start && python nipype_preproc_spm_auditory.py
     - cd examples/pipelining && python nipype_preproc_spm_multimodal_faces.py
     - cd examples/pipelining && python nistats_glm_fsl_feeds_fmri.py
+    - sh continuous_integration/clean_output.sh
 
 general:
   artifacts:
-    - "~/nilearn_data/spm_auditory/pypreprocess_output/sub001/reports"
-    - "~/nilearn_data/spm_multimodal_fmri/pypreprocess_output/sub001/reports"
-    - "~/nilearn_data/fsl_feeds/pypreprocess_output/sub001/reports"
+    - "/home/ubuntu/nilearn_data/spm_auditory/pypreprocess_output/"
+    - "~/nilearn_data/spm_multimodal_fmri/pypreprocess_output/"
+    - "~/nilearn_data/fsl_feeds/pypreprocess_output/"

--- a/circle.yml
+++ b/circle.yml
@@ -21,17 +21,21 @@ dependencies:
 
   override:
     # Installing pypreprocess
-    - python setup.py install
-    # Fetching Auditory dataset in order to be cached in the future
-    - python -c "from pypreprocess.datasets import fetch_spm_auditory; fetch_spm_auditory()"
+    - pip install -e .
+    # Fetching Auditory and Multimodal datasets in order to be cached in the future
+    - python -c "from pypreprocess import datasets; datasets.fetch_spm_auditory(); datasets.fetch_spm_multimodal_fmri(); datasets.fetch_fsl_feeds()"
+    # Caching terminates here. Outputs from test won't be saved. 
 
 test:
   override:
     - make clean
     - make test-code
     - cd examples/easy_start && python nipype_preproc_spm_auditory.py
+    - cd examples/pipelining && python nipype_preproc_spm_multimodal_faces.py
+    - cd examples/pipelining && python nistats_glm_fsl_feeds_fmri.py
 
 general:
   artifacts:
-    - "~/opt/spm8"
-    - "~/nilearn_data"
+    - "~/nilearn_data/spm_auditory/pypreprocess_output/sub001/reports"
+    - "~/nilearn_data/spm_multimodal_fmri/pypreprocess_output/sub001/reports"
+    - "~/nilearn_data/fsl_feeds/pypreprocess_output/sub001/reports"

--- a/circle.yml
+++ b/circle.yml
@@ -15,11 +15,9 @@ dependencies:
     # Installing SPM
     - source continuous_integration/setup_spm.sh
     # Installing Pypreprocess dependencies
-    - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-    - sudo apt-get install -qq python-scipy python-nose python-nibabel python-sklearn
     - pip install --upgrade pip
-    - pip install --upgrade nibabel
-    - pip install pandas nipype nilearn
+    - pip install scipy sklearn nibabel configobj nose 
+    - pip install matplotlib pandas nipype nilearn
 
   override:
     # Installing pypreprocess

--- a/continuous_integration/clean_output.sh
+++ b/continuous_integration/clean_output.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+# A script to delete cache, temporary and heavy files
+# for a given pypreprocess output
+
+
+remove_files(){
+  exts="*.nii *.nii.gz *.img *.hdr *.txt"
+  for ext in $exts
+  do
+    echo $ext $1
+    find $1 -name $ext -exec rm -rf {} \;
+  done 
+}
+
+remove_dirs(){
+  dirs="variance_maps effects_maps t_maps z_maps tmp Session1 Session2 QA cache_dir"
+  for dir in $dirs
+  do
+    p="$(find $1 -name $dir -type d)"
+    if [ ! -z "$p" ]
+    then
+      rm -rf $p
+      echo $p" deleted"
+    fi
+  done
+  find $1 -type d -empty -delete
+}
+
+# Main
+## Directories to clean
+paths="/home/ubuntu/nilearn_data/spm_auditory/pypreprocess_output/"
+paths="$paths /home/ubuntu/nilearn_data/spm_multimodal_fmri/pypreprocess_output/"
+paths="$paths /home/ubuntu/nilearn_data/fsl_feeds/pypreprocess_output/"
+
+## Main loop
+for path in $paths
+do
+  if [ -d "$path" ]
+  then
+    echo "Cleaning "$path
+    remove_files $path
+    remove_dirs $path
+  else
+    echo $path" not found"
+  fi
+done
+

--- a/examples/easy_start/nipype_preproc_spm_auditory.py
+++ b/examples/easy_start/nipype_preproc_spm_auditory.py
@@ -12,7 +12,7 @@ import nibabel
 from pypreprocess.nipype_preproc_spm_utils import do_subjects_preproc
 from pypreprocess.datasets import fetch_spm_auditory
 from pypreprocess.reporting.glm_reporter import generate_subject_stats_report
-from pandas import DataFrame
+import pandas as pd
 from pypreprocess.external.nistats.design_matrix import (make_design_matrix,
                                                          check_design_matrix,
                                                          plot_design_matrix)
@@ -36,7 +36,7 @@ conditions = ['rest', 'active'] * 8
 duration = epoch_duration * np.ones(len(conditions))
 onset = np.linspace(0, (len(conditions) - 1) * epoch_duration,
                     len(conditions))
-paradigm = DataFrame(
+paradigm = pd.DataFrame(
     {'onset': onset, 'duration': duration, 'name': conditions})
 
 hfcut = 2 * 2 * epoch_duration

--- a/examples/easy_start/nipype_preproc_spm_haxby.py
+++ b/examples/easy_start/nipype_preproc_spm_haxby.py
@@ -26,7 +26,7 @@ here</a>.\
 """
 
 # fetch HAXBY dataset
-N_SUBJECTS = 5
+N_SUBJECTS = 2
 haxby_data = fetch_haxby(n_subjects=N_SUBJECTS)
 
 # set output dir
@@ -51,7 +51,7 @@ for subject_id in set([os.path.basename(os.path.dirname(x))
     subject_data.func = subject_data.func[0]
 
     # set anat
-    subject_data.anat = [x for x in haxby_data.func if subject_id in x]
+    subject_data.anat = [x for x in haxby_data.anat if subject_id in x]
     assert len(subject_data.anat) == 1
     subject_data.anat = subject_data.anat[0]
 

--- a/examples/easy_start/nipype_preproc_spm_haxby.py
+++ b/examples/easy_start/nipype_preproc_spm_haxby.py
@@ -25,14 +25,15 @@ Get full description <a href="http://dev.pymvpa.org/datadb/haxby2001.html">\
 here</a>.\
 """
 
-# set output dir
-OUTPUT_DIR = "haxby_runs"
-if not os.path.exists(OUTPUT_DIR):
-    os.makedirs(OUTPUT_DIR)
-
 # fetch HAXBY dataset
 N_SUBJECTS = 5
 haxby_data = fetch_haxby(n_subjects=N_SUBJECTS)
+
+# set output dir
+OUTPUT_DIR = os.path.join(os.path.dirname(haxby_data.mask),
+                          "haxby_runs")
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
 
 # get subject data
 subjects = []

--- a/examples/pipelining/nipype_preproc_spm_multimodal_faces.py
+++ b/examples/pipelining/nipype_preproc_spm_multimodal_faces.py
@@ -16,7 +16,7 @@ import scipy.io
 from pypreprocess.external.nistats.design_matrix import (make_design_matrix,
                                                          check_design_matrix)
 from pypreprocess.external.nistats.glm import FMRILinearModel
-from pandas import DataFrame
+import pandas as pd
 
 # pypreprocess imports
 from pypreprocess.datasets import fetch_spm_multimodal_fmri
@@ -79,7 +79,7 @@ for x in xrange(2):
 
     # build design matrix
     frametimes = np.linspace(0, (n_scans - 1) * tr, n_scans)
-    paradigm = DataFrame({'name': conditions, 'onset': onsets})
+    paradigm = pd.DataFrame({'name': conditions, 'onset': onsets})
     design_matrix = make_design_matrix(frametimes, paradigm,
                                        hrf_model=hrf_model,
                                        drift_model=drift_model,

--- a/examples/pipelining/nipype_preproc_spm_multimodal_faces.py
+++ b/examples/pipelining/nipype_preproc_spm_multimodal_faces.py
@@ -43,7 +43,7 @@ dataset_dir = os.path.dirname(os.path.dirname(os.path.dirname(
 # preprocess the data
 subject_id = "sub001"
 subject_data = SubjectData(
-    output_dir=os.path.join(dataset_dir, "pypreprocess", subject_id),
+    output_dir=os.path.join(dataset_dir, "pypreprocess_output", subject_id),
     subject_id=subject_id, func=[subject_data.func1, subject_data.func2],
     anat=subject_data.anat, trials_ses1=subject_data.trials_ses1,
     trials_ses2=subject_data.trials_ses2, session_ids=["Session1", "Session2"])
@@ -85,13 +85,6 @@ for x in xrange(2):
                                        drift_model=drift_model,
                                        period_cut=hfcut)
     design_matrices.append(design_matrix)
-
-    """
-    design_matrix = make_dmtx(
-        frametimes, paradigm, hrf_model=hrf_model, drift_model=drift_model,
-        hfcut=hfcut, add_reg_names=['tx', 'ty', 'tz', 'rx', 'ry', 'rz'],
-        add_regs=np.loadtxt(subject_data.realignment_parameters[x]))
-    """
 
 # specify contrasts
 _, matrix, names = check_design_matrix(design_matrix)

--- a/examples/pipelining/nistats_glm_fsl_feeds_fmri.py
+++ b/examples/pipelining/nistats_glm_fsl_feeds_fmri.py
@@ -22,9 +22,6 @@ from pypreprocess.io_utils import compute_mean_3D_image
 """MISC"""
 DATASET_DESCRIPTION = "FSL FEEDS example data (single-subject)"
 
-"""sanitize cmd line"""
-output_dir = "/tmp/fsl_feeds"
-
 """experimental setup"""
 stats_start_time = time.ctime()
 n_scans = 180
@@ -42,7 +39,6 @@ EV2_on = 45
 conditions = ['EV1'] * EV1_epochs + ['EV2'] * EV2_epochs
 onset = list(EV1_onset) + list(EV2_onset)
 duration = [EV1_on] * EV1_epochs + [EV2_on] * EV2_epochs
-# paradigm = BlockParadigm(con_id=conditions, onset=onset, duration=duration)
 paradigm = DataFrame({'name': conditions, 'onset': onset,
                       'duration': duration})
 frametimes = np.linspace(0, (n_scans - 1) * TR, n_scans)
@@ -52,10 +48,6 @@ hfcut = 1.5 * maximum_epoch_duration  # why ?
 """construct design matrix"""
 drift_model = 'Cosine'
 hrf_model = 'Canonical With Derivative'
-# design_matrix = make_dmtx(frametimes,
-#                          paradigm, hrf_model=hrf_model,
-#                          drift_model=drift_model, hfcut=hfcut)
-
 design_matrix = make_design_matrix(frame_times=frametimes,
                                    paradigm=paradigm,
                                    hrf_model=hrf_model,
@@ -68,8 +60,14 @@ subject_data = SubjectData()
 subject_data.subject_id = "sub001"
 subject_data.func = _subject_data.func
 subject_data.anat = _subject_data.anat
+
+output_dir = os.path.join(_subject_data.data_dir, "pypreprocess_output")
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
 subject_data.output_dir = os.path.join(
     output_dir, subject_data.subject_id)
+
+
 
 """preprocess the data"""
 results = do_subjects_preproc(

--- a/examples/pipelining/nistats_glm_fsl_feeds_fmri.py
+++ b/examples/pipelining/nistats_glm_fsl_feeds_fmri.py
@@ -6,7 +6,7 @@ on FSL's FEEDS fMRI single-subject example data
 
 import os
 import numpy as np
-from pandas import DataFrame
+import pandas as pd
 from pypreprocess.external.nistats.design_matrix import (make_design_matrix,
                                                          check_design_matrix)
 from pypreprocess.external.nistats.glm import FMRILinearModel
@@ -39,8 +39,8 @@ EV2_on = 45
 conditions = ['EV1'] * EV1_epochs + ['EV2'] * EV2_epochs
 onset = list(EV1_onset) + list(EV2_onset)
 duration = [EV1_on] * EV1_epochs + [EV2_on] * EV2_epochs
-paradigm = DataFrame({'name': conditions, 'onset': onset,
-                      'duration': duration})
+paradigm = pd.DataFrame({'name': conditions, 'onset': onset,
+                         'duration': duration})
 frametimes = np.linspace(0, (n_scans - 1) * TR, n_scans)
 maximum_epoch_duration = max(EV1_epoch_duration, EV2_epoch_duration)
 hfcut = 1.5 * maximum_epoch_duration  # why ?

--- a/pypreprocess/external/nistats/design_matrix.py
+++ b/pypreprocess/external/nistats/design_matrix.py
@@ -1,0 +1,428 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import with_statement
+"""
+This module implements fMRI Design Matrix creation.
+
+The DesignMatrix object is just a container that represents the design matrix.
+Computations of the different parts of the design matrix are confined
+to the make_dmtx() function, that instantiates the DesignMatrix object.
+All the remainder are just ancillary functions.
+
+Design matrices contain three different types of regressors:
+
+1. Task-related regressors, that result from the convolution
+   of the experimental paradigm regressors with hemodynamic models
+   A hemodynamic model is one of:
+   'spm' : linear filter used in the SPM software
+   'glover' : linear filter estimated by G.Glover
+   'fir' : finite impulse response model, generic linear filter
+
+2. User-specified regressors, that represent information available on
+   the data, e.g. motion parameters, physiological data resampled at
+   the acquisition rate, or sinusoidal regressors that model the
+   signal at a frequency of interest.
+
+3. Drift regressors, that represent low_frequency phenomena of no
+   interest in the data; they need to be included to reduce variance
+   estimates.
+
+Author: Bertrand Thirion, 2009-2015
+"""
+from warnings import warn
+import numpy as np
+import scipy.linalg as spl
+from pandas import DataFrame
+
+from .hemodynamic_models import compute_regressor, _orthogonalize
+from .experimental_paradigm import check_paradigm
+
+
+
+######################################################################
+# Ancillary functions
+######################################################################
+
+
+def _poly_drift(order, frame_times):
+    """Create a polynomial drift matrix
+
+    Parameters
+    ----------
+    order : int,
+        number of polynomials in the drift model
+
+    frame_times : array of shape(n_scans),
+        time stamps used to sample polynomials
+
+    Returns
+    -------
+    pol : ndarray, shape(n_scans, order + 1)
+         estimated polynomial drifts plus a constant regressor
+    """
+    order = int(order)
+    pol = np.zeros((np.size(frame_times), order + 1))
+    tmax = float(frame_times.max())
+    for k in range(order + 1):
+        pol[:, k] = (frame_times / tmax) ** k
+    pol = _orthogonalize(pol)
+    pol = np.hstack((pol[:, 1:], pol[:, :1]))
+    return pol
+
+
+def _cosine_drift(period_cut, frame_times):
+    """Create a cosine drift matrix with periods greater or equal to
+    period_cut.
+
+    Parameters
+    ----------
+    period_cut : float
+        Cut period of the low-pass filter (in sec)
+
+    frame_times : array of shape(n_scans)
+        The sampling times (in sec)
+
+    Returns
+    -------
+    cosine_drift : array of shape(n_scans, n_drifts)
+        Cosine drifts plus a constant regressor at cosine_drift[:, -1]
+
+    Ref: http://en.wikipedia.org/wiki/Discrete_cosine_transform DCT-II
+    """
+    n_frames = len(frame_times)
+    n_times = np.arange(n_frames)
+    hfcut = 1. / period_cut  # input parameter is the period
+    dt = frame_times[1] - frame_times[0]
+    order = int(np.floor(2 * n_frames * hfcut * dt))
+    # s.t. hfcut = 1 / (2 * dt) yields n_frames
+    cosine_drift = np.zeros((n_frames, order))
+    normalizer = np.sqrt(2.0 / n_frames)
+
+    for k in range(1, order):
+        cosine_drift[:, k - 1] = normalizer * np.cos(
+            (np.pi / n_frames) * (n_times + .5) * k)
+
+    cosine_drift[:, order - 1] = 1.
+    return cosine_drift
+
+
+def _blank_drift(frame_times):
+    """ Create the blank drift matrix
+
+    Returns
+    -------
+    np.ones_like(frame_times)
+    """
+    return np.reshape(np.ones_like(frame_times), (np.size(frame_times), 1))
+
+
+def _make_drift(drift_model, frame_times, order=1, period_cut=128.):
+    """Create the drift matrix
+
+    Parameters
+    ----------
+    drift_model : {'polynomial', 'cosine', 'blank'},
+        string that specifies the desired drift model
+
+    frame_times : array of shape(n_scans),
+        list of values representing the desired TRs
+
+    order : int, optional,
+        order of the drift model (in case it is polynomial)
+
+    period_cut : float, optional (defaults to 128),
+        period cut in case of a cosine model (in seconds)
+
+    Returns
+    -------
+    drift : array of shape(n_scans, n_drifts),
+        the drift matrix
+
+    names : list of length(n_drifts),
+        the associated names
+    """
+    drift_model = drift_model.lower()   # for robust comparisons
+    if drift_model == 'polynomial':
+        drift = _poly_drift(order, frame_times)
+    elif drift_model == 'cosine':
+        drift = _cosine_drift(period_cut, frame_times)
+    elif drift_model == 'blank':
+        drift = _blank_drift(frame_times)
+    else:
+        raise NotImplementedError("Unknown drift model %r" % (drift_model))
+    names = []
+    for k in range(1, drift.shape[1]):
+        names.append('drift_%d' % k)
+    names.append('constant')
+    return drift, names
+
+
+def _convolve_regressors(paradigm, hrf_model, frame_times, fir_delays=[0],
+                         min_onset=-24):
+    """ Creation of  a matrix that comprises
+    the convolution of the conditions onset with a certain hrf model
+
+    Parameters
+    ----------
+    paradigm : DataFrame instance,
+        Descriptor of an experimental paradigm
+        see nistats.experimental_paradigm to check the specification
+        for these to be valid paradigm descriptors
+
+    hrf_model : {'canonical', 'canonical with derivative', 'fir'}
+        string that specifies the hemodynamic response function
+
+    frame_times : array of shape(n_scans)
+        the targeted timing for the design matrix
+
+    fir_delays : array-like of shape(nb_onsets), optional,
+        in case of FIR design, yields the array of delays
+        used in the FIR model
+
+    min_onset : float, optional (default: -24),
+        minimal onset relative to frame_times[0] (in seconds)
+        events that start before frame_times[0] + min_onset are not considered
+
+    Returns
+    -------
+    regressor_matrix : array of shape(n_scans, n_regressors),
+        contains the convolved regressors
+        associated with the experimental conditions
+
+    regressor_names : list of strings,
+        the regressor names, that depend on the hrf model used
+        if 'canonical' then this is identical to the input names
+        if 'canonical with derivative', then two names are produced for
+        input name 'name': 'name' and 'name_derivative'
+    """
+    regressor_names = []
+    regressor_matrix = None
+    if hrf_model == 'fir':
+        oversampling = 1
+    else:
+        oversampling = 16
+
+    name, onset, duration, modulation = check_paradigm(paradigm)
+    for condition in np.unique(paradigm.name):
+        condition_mask = (name == condition)
+        exp_condition = (onset[condition_mask],
+                         duration[condition_mask],
+                         modulation[condition_mask])
+        reg, names = compute_regressor(
+            exp_condition, hrf_model, frame_times, con_id=condition,
+            fir_delays=fir_delays, oversampling=oversampling,
+            min_onset=min_onset)
+        regressor_names += names
+        if regressor_matrix is None:
+            regressor_matrix = reg
+        else:
+            regressor_matrix = np.hstack((regressor_matrix, reg))
+    return regressor_matrix, regressor_names
+
+
+def _full_rank(X, cmax=1e15):
+    """ Computes the condition number of X and if it is larger than cmax,
+    returns a matrix with a condition number smaller than cmax.
+
+    Parameters
+    ----------
+    X : array of shape(nrows, ncols)
+        input array
+
+    cmax : float, optional (default:1.e-15),
+        tolerance for condition number
+
+    Returns
+    -------
+    X : array of shape(nrows, ncols)
+        output array
+
+    cond : float,
+        actual condition number
+    """
+    U, s, V = spl.svd(X, 0)
+    smax, smin = s.max(), s.min()
+    cond = smax / smin
+    if cond < cmax:
+        return X, cond
+
+    warn('Matrix is singular at working precision, regularizing...')
+    lda = (smax - cmax * smin) / (cmax - 1)
+    X = np.dot(U, np.dot(np.diag(s + lda), V))
+    return X, cmax
+
+
+######################################################################
+# Design matrix creation
+######################################################################
+
+
+def make_design_matrix(
+    frame_times, paradigm=None, hrf_model='canonical',
+    drift_model='cosine', period_cut=128, drift_order=1, fir_delays=[0],
+    add_regs=None, add_reg_names=None, min_onset=-24):
+    """ Generate a design matrix from the input parameters
+
+    Parameters
+    ----------
+    frame_times : array of shape(n_frames),
+        the timing of the scans
+
+    paradigm : DataFrame instance, optional
+        description of the experimental paradigm
+
+    hrf_model : string, optional,
+        that specifies the hemodynamic response function
+        it can be 'canonical', 'canonical with derivative' or 'fir'
+
+    drift_model : string, optional
+        specifies the desired drift model,
+        to be chosen among 'polynomial', 'cosine', 'blank'
+
+    period_cut : float, optional
+        cut period of the low-pass filter in seconds
+
+    drift_order : int, optional
+        order of the drift model (in case it is polynomial)
+
+    fir_delays : array of shape(n_onsets) or list, optional,
+        in case of FIR design, yields the array of delays used in the FIR model
+
+    add_regs : array of shape(n_frames, n_add_reg), optional
+        additional user-supplied regressors
+
+    add_reg_names : list of (n_add_reg) strings, optional
+        if None, while n_add_reg > 0, these will be termed
+        'reg_%i', i = 0..n_add_reg - 1
+
+    min_onset : float, optional
+        minimal onset relative to frame_times[0] (in seconds)
+        events that start before frame_times[0] + min_onset are not considered
+
+    Returns
+    -------
+    design_matrix : DataFrame instance,
+        holding the computed design matrix
+    """
+    # check arguments
+    # check that additional regressor specification is correct
+    n_add_regs = 0
+    if add_regs is not None:
+        if add_regs.shape[0] == np.size(add_regs):
+            add_regs = np.reshape(add_regs, (np.size(add_regs), 1))
+        n_add_regs = add_regs.shape[1]
+        assert add_regs.shape[0] == np.size(frame_times), ValueError(
+            'incorrect specification of additional regressors: '
+            'length of regressors provided: %s, number of ' +
+            'time-frames: %s' % (add_regs.shape[0], np.size(frame_times)))
+
+    # check that additional regressor names are well specified
+    if add_reg_names is None:
+        add_reg_names = ['reg%d' % k for k in range(n_add_regs)]
+    elif len(add_reg_names) != n_add_regs:
+        raise ValueError(
+            'Incorrect number of additional regressor names was provided'
+            '(%s provided, %s expected) % (len(add_reg_names),'
+            'n_add_regs)')
+
+    # computation of the matrix
+    names = []
+    matrix = np.zeros((frame_times.size, 0))
+
+    # step 1: paradigm-related regressors
+    if paradigm is not None:
+        # create the condition-related regressors
+        matrix, names = _convolve_regressors(
+            paradigm, hrf_model.lower(), frame_times, fir_delays, min_onset)
+
+    # step 2: additional regressors
+    if add_regs is not None:
+        # add user-supplied regressors and corresponding names
+        matrix = np.hstack((matrix, add_regs))
+        names += add_reg_names
+
+    # step 3: drifts
+    drift, dnames = _make_drift(drift_model.lower(), frame_times, drift_order,
+                                period_cut)
+    matrix = np.hstack((matrix, drift))
+    names += dnames
+
+    # step 4: Force the design matrix to be full rank at working precision
+    matrix, _ = _full_rank(matrix)
+
+    design_matrix = DataFrame(
+        np.hstack((frame_times[:, np.newaxis], matrix)),
+        columns=['frame_times'] + names)
+    return design_matrix
+
+
+def check_design_matrix(design_matrix):
+    """ Check that the provided DataFrame is indeed a valid design matrix
+    descriptor, and returns a triplet of fields
+
+    Parameters
+    ----------
+    design matrix : pandas DataFrame,
+        describes a design matrix
+
+    Returns
+    -------
+    frame_times : array of shape (n_frames),
+        sampling times of the design matrix
+
+    matrix : array of shape (n_frames, n_regressors), dtype='f'
+        numerical values for the design matrix
+
+    names : array of shape (n_events), dtype='f'
+           per-event onset time (in seconds)
+    """
+    names = design_matrix.keys()
+    if 'frame_times' not in names:
+        raise ValueError('The provided DataFrame does not contain the'
+                         'mandatory frame_times field')
+    frame_times = design_matrix['frame_times']
+    names = list(names.drop('frame_times'))
+    matrix = design_matrix[names].values
+    return frame_times, matrix, names
+
+
+def plot_design_matrix(design_matrix, rescale=True, ax=None):
+    """ Plot a design matrix provided as a DataFrame
+
+    Parameters
+    ----------
+    design matrix : pandas DataFrame,
+        describes a design matrix
+
+    rescale : bool, optional
+        rescale columns magnitude for visualization or not
+
+    ax : axis handle, optional
+        Handle to axis onto which we will draw design matrix
+
+    Returns
+    -------
+    ax: axis handle
+    """
+    # We import _set_mpl_backend because just the fact that we are
+    # importing it sets the backend
+    from nilearn.plotting import _set_mpl_backend
+    # avoid unhappy pyflackes
+    _set_mpl_backend
+    import matplotlib.pyplot as plt
+
+    # normalize the values per column for better visualization
+    _, X, names = check_design_matrix(design_matrix)
+    if rescale:
+        X = X / np.maximum(1.e-12, np.sqrt(np.sum(X ** 2, 0)))
+    if ax is None:
+        plt.figure()
+        ax = plt.subplot(1, 1, 1)
+
+    ax.imshow(X, interpolation='Nearest', aspect='auto')
+    ax.set_label('conditions')
+    ax.set_ylabel('scan number')
+
+    ax.set_xticks(range(len(names)))
+    ax.set_xticklabels(names, rotation=60, ha='right')
+    return ax

--- a/pypreprocess/external/nistats/experimental_paradigm.py
+++ b/pypreprocess/external/nistats/experimental_paradigm.py
@@ -1,0 +1,78 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import with_statement
+"""
+An experimental protocol is handled as a pandas DataFrame
+that includes an 'onset' field.
+This yields the onset time of the events in the paradigm. It can also contain:
+* a 'name' field that yields the condition identifier.
+* a 'duration' field that yields event duration (for so-called block
+  paradigms).
+* a 'modulation' field that associated a scalar value to each event.
+
+Author: Bertrand Thirion, 2015
+"""
+
+import numpy as np
+
+
+def check_paradigm(paradigm):
+    """ test that the DataFrame is describes a valid experimental paradigm
+    A DataFrame is considered as valid whenever it has an 'onset' key.
+
+    Parameters
+    ----------
+    paradigm : pandas DataFrame
+        describes a functional paradigm
+
+    Returns
+    -------
+    name : array of shape (n_events), dtype='s'
+        per-event experimental conditions identifier
+        Defaults to np.repeat('dummy', len(onsets))
+
+    onset : array of shape (n_events), dtype='f'
+        per-event onset time (in seconds)
+
+    duration : array of shape (n_events), dtype='f'
+        per-event durantion, (in seconds)
+        defaults to zeros(n_events) when no duration is provided
+
+    modulation : array of shape (n_events), dtype='f'
+        per-event modulation, (in seconds)
+        defaults to ones(n_events) when no duration is provided
+
+    """
+    if 'onset' not in paradigm.keys():
+        raise ValueError('The provided paradigm has no onset key')
+
+    onset = np.array(paradigm['onset'])
+    n_events = len(onset)
+    name = np.repeat('dummy', n_events)
+    duration = np.zeros(n_events)
+    modulation = np.ones(n_events)
+    if 'name' in paradigm.keys():
+        name = np.array(paradigm['name'])
+    if 'duration' in paradigm.keys():
+        duration = np.array(paradigm['duration']).astype(np.float)
+    if 'modulation' in paradigm.keys():
+        modulation = np.array(paradigm['modulation']).astype(np.float)
+    return name, onset, duration, modulation
+
+
+def paradigm_from_csv(csv_file):
+    """ Utility function to directly read the paradigm from a csv file
+    This is simply meant to explicitly import pandas everywhere
+
+    Parameters
+    ----------
+    csv_file : string,
+        path to a csv file
+
+    Returns
+    -------
+    paradigm : pandas DataFrame,
+        holding the paradigm information
+    """
+    import pandas
+    return pandas.DataFrame().from_csv(csv_file)

--- a/pypreprocess/external/nistats/glm.py
+++ b/pypreprocess/external/nistats/glm.py
@@ -15,7 +15,7 @@ Examples
 --------
 
 >>> import numpy as np
->>> from nistats.glm import GeneralLinearModel
+>>> from pypreprocess.external.nistats.glm import GeneralLinearModel
 >>> n, p, q = 100, 80, 10
 >>> X, Y = np.random.randn(p, q), np.random.randn(p, n)
 >>> cval = np.hstack((1, np.zeros(9)))

--- a/pypreprocess/external/nistats/glm.py
+++ b/pypreprocess/external/nistats/glm.py
@@ -1,0 +1,612 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+This module presents an interface to use the glm implemented in
+nistats.regression.
+
+It contains the GLM and contrast classes that are meant to be the main objects
+of fMRI data analyses.
+
+It is important to note that the GLM is meant as a one-session General Linear
+Model. But inference can be performed on multiple sessions by computing fixed
+effects on contrasts
+
+Examples
+--------
+
+>>> import numpy as np
+>>> from nistats.glm import GeneralLinearModel
+>>> n, p, q = 100, 80, 10
+>>> X, Y = np.random.randn(p, q), np.random.randn(p, n)
+>>> cval = np.hstack((1, np.zeros(9)))
+>>> model = GeneralLinearModel(X)
+>>> model.fit(Y)
+>>> z_vals = model.contrast(cval).z_score() # z-transformed statistics
+
+Example of fixed effects statistics across two contrasts
+
+>>> cval_ = cval.copy()
+>>> np.random.shuffle(cval_)
+>>> z_ffx = (model.contrast(cval) + model.contrast(cval_)).z_score()
+"""
+
+import numpy as np
+
+from warnings import warn
+
+import scipy.stats as sps
+
+from nibabel import load, Nifti1Image
+
+from nilearn.masking import compute_multi_epi_mask as compute_mask_sessions
+from .regression import OLSModel, ARModel
+from .utils import multiple_mahalanobis, z_score, _basestring
+
+DEF_TINY = 1e-50
+DEF_DOFMAX = 1e10
+
+
+def data_scaling(Y):
+    """Scaling of the data to have percent of baseline change columnwise
+
+    Parameters
+    ----------
+    Y : array of shape(n_time_points, n_voxels)
+       the input data
+
+    Returns
+    -------
+    Y : array of shape (n_time_points, n_voxels),
+       the data after mean-scaling, de-meaning and multiplication by 100
+    mean : array of shape (n_voxels,)
+        the data mean
+    """
+    mean = Y.mean(0)
+    Y = 100 * (Y / mean - 1)
+    return Y, mean
+
+
+class GeneralLinearModel(object):
+    """ This class handles the so-called on General Linear Model
+
+    Most of what it does in the fit() and contrast() methods
+    fit() performs the standard two-step ('ols' then 'ar1') GLM fitting
+    contrast() returns a contrast instance, yileding statistics and p-values.
+    The link between fit() and constrast is done vis the two class members:
+
+    glm_results : dictionary of nistats.regression.RegressionResults instances,
+                 describing results of a GLM fit
+
+    labels : array of shape(n_voxels),
+            labels that associate each voxel with a results key
+    """
+
+    def __init__(self, X):
+        """
+        Parameters
+        ----------
+        X : array of shape (n_time_points, n_regressors)
+           the design matrix
+        """
+        self.X = X
+        self.labels_ = None
+        self.results_ = None
+
+    def fit(self, Y, model='ar1', bins=100):
+        """GLM fitting of a dataset using 'ols' regression or the two-pass
+
+        Parameters
+        ----------
+        Y : array of shape(n_time_points, n_samples)
+            the fMRI data
+        model : {'ar1', 'ols'}, optional
+            the temporal variance model. Defaults to 'ar1'
+        bins : int, optional
+            Maximum number of discrete bins for the AR(1) coef histogram
+        """
+        if model not in ['ar1', 'ols']:
+            raise ValueError('Unknown model')
+
+        if Y.ndim == 1:
+            Y = Y[:, np.newaxis]
+
+        if Y.shape[0] != self.X.shape[0]:
+            raise ValueError('Response and predictors are inconsistent')
+
+        # fit the OLS model
+        ols_result = OLSModel(self.X).fit(Y)
+
+        # compute and discretize the AR1 coefs
+        ar1 = ((ols_result.resid[1:] * ols_result.resid[:-1]).sum(0) /
+               (ols_result.resid ** 2).sum(0))
+        ar1 = (ar1 * bins).astype(np.int) * 1. / bins
+
+        # Fit the AR model acccording to current AR(1) estimates
+        if model == 'ar1':
+            self.results_ = {}
+            self.labels_ = ar1
+            # fit the model
+            for val in np.unique(self.labels_):
+                m = ARModel(self.X, val)
+                self.results_[val] = m.fit(Y[:, self.labels_ == val])
+        else:
+            self.labels_ = np.zeros(Y.shape[1])
+            self.results_ = {0.0: ols_result}
+
+    def get_beta(self, column_index=None):
+        """Acessor for the best linear unbiased estimated of model parameters
+
+        Parameters
+        ----------
+        column_index : int or array-like of int or None, optional
+            The indexed of the columns to be returned.  if None (default
+            behaviour), the whole vector is returned
+
+        Returns
+        -------
+        beta: array of shape (n_voxels, n_columns)
+            the required coefficients
+        """
+        # make colum_index a list if it an int
+        if column_index is None:
+            column_index = np.arange(self.X.shape[1])
+        if not hasattr(column_index, '__iter__'):
+            column_index = [int(column_index)]
+        n_beta = len(column_index)
+
+        # build the beta array
+        beta = np.zeros((n_beta, self.labels_.size), dtype=np.float)
+        for l in self.results_.keys():
+            beta[:, self.labels_ == l] = self.results_[l].theta[column_index]
+        return beta
+
+    def get_mse(self):
+        """Acessor for the mean squared error of the model
+
+        Returns
+        -------
+        mse: array of shape (n_voxels)
+            the sum of square error per voxel
+        """
+        # build the beta array
+        mse = np.zeros(self.labels_.size, dtype=np.float)
+        for l in self.results_.keys():
+            mse[self.labels_ == l] = self.results_[l].MSE
+        return mse
+
+    def get_logL(self):
+        """Acessor for the log-likelihood of the model
+
+        Returns
+        -------
+        logL: array of shape (n_voxels,)
+            the sum of square error per voxel
+        """
+        # build the beta array
+        logL = np.zeros(self.labels_.size, dtype=np.float)
+        for l in self.results_.keys():
+            logL[self.labels_ == l] = self.results_[l].logL
+        return logL
+
+    def contrast(self, con_val, contrast_type=None):
+        """ Specify and estimate a linear contrast
+
+        Parameters
+        ----------
+        con_val : numpy.ndarray of shape (p) or (q, p)
+            where q = number of contrast vectors and p = number of regressors
+
+        contrast_type : {None, 't', 'F' or 'tmin-conjunction'}, optional
+            type of the contrast.  If None, then defaults to 't' for 1D
+            `con_val` and 'F' for 2D `con_val`
+
+        Returns
+        -------
+        con: Contrast instance
+        """
+        if self.labels_ is None or self.results_ is None:
+            raise ValueError('The model has not been estimated yet')
+        con_val = np.asarray(con_val)
+        if con_val.ndim == 1:
+            dim = 1
+        else:
+            dim = con_val.shape[0]
+        if contrast_type is None:
+            if dim == 1:
+                contrast_type = 't'
+            else:
+                contrast_type = 'F'
+        if contrast_type not in ['t', 'F', 'tmin-conjunction']:
+            raise ValueError('Unknown contrast type: %s' % contrast_type)
+
+        effect_ = np.zeros((dim, self.labels_.size), dtype=np.float)
+        var_ = np.zeros((dim, dim, self.labels_.size), dtype=np.float)
+        if contrast_type == 't':
+            for l in self.results_.keys():
+                resl = self.results_[l].Tcontrast(con_val)
+                effect_[:, self.labels_ == l] = resl.effect.T
+                var_[:, :, self.labels_ == l] = (resl.sd ** 2).T
+        else:
+            for l in self.results_.keys():
+                resl = self.results_[l].Fcontrast(con_val)
+                effect_[:, self.labels_ == l] = resl.effect
+                var_[:, :, self.labels_ == l] = resl.covariance
+
+        dof_ = self.results_[l].df_resid
+        return Contrast(effect=effect_, variance=var_, dof=dof_,
+                        contrast_type=contrast_type)
+
+
+class Contrast(object):
+    """ The contrast class handles the estimation of statistical contrasts
+    on a given model: student (t), Fisher (F), conjunction (tmin-conjunction).
+    The important feature is that it supports addition,
+    thus opening the possibility of fixed-effects models.
+
+    The current implementation is meant to be simple,
+    and could be enhanced in the future on the computational side
+    (high-dimensional F constrasts may lead to memory breakage).
+
+    Notes
+    -----
+    The 'tmin-conjunction' test is the valid conjunction test discussed in:
+    Nichols T, Brett M, Andersson J, Wager T, Poline JB. Valid conjunction
+    inference with the minimum statistic. Neuroimage. 2005 Apr 15;25(3):653-60.
+    This test gives the p-value of the z-values under the conjunction null,
+    i.e. the union of the null hypotheses for all terms.
+    """
+
+    def __init__(self, effect, variance, dof=DEF_DOFMAX, contrast_type='t',
+                 tiny=DEF_TINY, dofmax=DEF_DOFMAX):
+        """
+        Parameters
+        ----------
+        effect : array of shape (contrast_dim, n_voxels)
+            the effects related to the contrast
+
+        variance : array of shape (contrast_dim, contrast_dim, n_voxels)
+            the associated variance estimate
+
+        dof : scalar
+            the degrees of freedom of the resiudals
+
+        contrast_type: {'t', 'F'}
+            specification of the contrast type
+        """
+        if variance.ndim != 3:
+            raise ValueError('Variance array should have 3 dimensions')
+        if effect.ndim != 2:
+            raise ValueError('Variance array should have 2 dimensions')
+        if variance.shape[0] != variance.shape[1]:
+            raise ValueError('Inconsistent shape for the variance estimate')
+        if ((variance.shape[1] != effect.shape[0]) or
+            (variance.shape[2] != effect.shape[1])):
+            raise ValueError('Effect and variance have inconsistent shape')
+
+        self.effect = effect
+        self.variance = variance
+        self.dof = float(dof)
+        self.dim = effect.shape[0]
+        if self.dim > 1 and contrast_type is 't':
+            print('Automatically converted multi-dimensional t to F contrast')
+            contrast_type = 'F'
+        self.contrast_type = contrast_type
+        self.stat_ = None
+        self.p_value_ = None
+        self.baseline = 0
+        self.tiny = tiny
+        self.dofmax = dofmax
+
+    def stat(self, baseline=0.0):
+        """ Return the decision statistic associated with the test of the
+        null hypothesis: (H0) 'contrast equals baseline'
+
+        Parameters
+        ----------
+        baseline : float, optional
+            Baseline value for the test statistic
+
+        Returns
+        -------
+        stat: 1-d array, shape=(n_voxels,)
+            statistical values, one per voxel
+        """
+        self.baseline = baseline
+
+        # Case: one-dimensional contrast ==> t or t**2
+        if self.dim == 1:
+            # avoids division by zero
+            stat = (self.effect - baseline) / np.sqrt(
+                np.maximum(self.variance, self.tiny))
+            if self.contrast_type == 'F':
+                stat = stat ** 2
+        # Case: F contrast
+        elif self.contrast_type == 'F':
+            # F = |t|^2/q ,  |t|^2 = e^t inv(v) e
+            if self.effect.ndim == 1:
+                self.effect = self.effect[np.newaxis]
+            if self.variance.ndim == 1:
+                self.variance = self.variance[np.newaxis, np.newaxis]
+            stat = (multiple_mahalanobis(
+                    self.effect - baseline, self.variance) / self.dim)
+        # Case: tmin (conjunctions)
+        elif self.contrast_type == 'tmin-conjunction':
+            vdiag = self.variance.reshape([self.dim ** 2] + list(
+                    self.variance.shape[2:]))[:: self.dim + 1]
+            stat = (self.effect - baseline) / np.sqrt(
+                np.maximum(vdiag, self.tiny))
+            stat = stat.min(0)
+
+        # Unknwon stat
+        else:
+            raise ValueError('Unknown statistic type')
+        self.stat_ = stat
+        return stat.ravel()
+
+    def p_value(self, baseline=0.0):
+        """Return a parametric estimate of the p-value associated
+        with the null hypothesis: (H0) 'contrast equals baseline'
+
+        Parameters
+        ----------
+        baseline : float, optional
+            baseline value for the test statistic
+
+        Returns
+        -------
+        p_values : 1-d array, shape=(n_voxels,)
+            p-values, one per voxel
+        """
+        if self.stat_ is None or not self.baseline == baseline:
+            self.stat_ = self.stat(baseline)
+        # Valid conjunction as in Nichols et al, Neuroimage 25, 2005.
+        if self.contrast_type in ['t', 'tmin-conjunction']:
+            p_values = sps.t.sf(self.stat_, np.minimum(self.dof, self.dofmax))
+        elif self.contrast_type == 'F':
+            p_values = sps.f.sf(self.stat_, self.dim, np.minimum(
+                    self.dof, self.dofmax))
+        else:
+            raise ValueError('Unknown statistic type')
+        self.p_value_ = p_values
+        return p_values
+
+    def z_score(self, baseline=0.0):
+        """Return a parametric estimation of the z-score associated
+        with the null hypothesis: (H0) 'contrast equals baseline'
+
+        Parameters
+        ----------
+        baseline: float, optional,
+                  Baseline value for the test statistic
+
+        Returns
+        -------
+        z_score: 1-d array, shape=(n_voxels,)
+            statistical values, one per voxel
+
+        """
+        if self.p_value_ is None or not self.baseline == baseline:
+            self.p_value_ = self.p_value(baseline)
+
+        # Avoid inf values kindly supplied by scipy.
+        self.z_score_ = z_score(self.p_value_)
+        return self.z_score_
+
+    def __add__(self, other):
+        """Addition of selfwith others, Yields an new Contrast instance
+        This should be used only on indepndent contrasts"""
+        if self.contrast_type != other.contrast_type:
+            raise ValueError(
+                'The two contrasts do not have consistant type dimensions')
+        if self.dim != other.dim:
+            raise ValueError(
+                'The two contrasts do not have compatible dimensions')
+        effect_ = self.effect + other.effect
+        variance_ = self.variance + other.variance
+        dof_ = self.dof + other.dof
+        return Contrast(effect=effect_, variance=variance_, dof=dof_,
+                        contrast_type=self.contrast_type)
+
+    def __rmul__(self, scalar):
+        """Multiplication of the contrast by a scalar"""
+        scalar = float(scalar)
+        effect_ = self.effect * scalar
+        variance_ = self.variance * scalar ** 2
+        dof_ = self.dof
+        return Contrast(effect=effect_, variance=variance_, dof=dof_,
+                        contrast_type=self.contrast_type)
+
+    __mul__ = __rmul__
+
+    def __div__(self, scalar):
+        return self.__rmul__(1 / float(scalar))
+
+
+class FMRILinearModel(object):
+    """ This class is meant to handle GLMs from a higher-level perspective
+    i.e. by taking images as input and output
+    """
+
+    def __init__(self, fmri_data, design_matrices, mask='compute',
+                 m=0.2, M=0.9, threshold=.5):
+        """Load the data
+
+        Parameters
+        ----------
+        fmri_data : Image or str or sequence of Images / str
+            fmri images / paths of the (4D) fmri images
+
+        design_matrices : arrays or str or sequence of arrays / str
+            design matrix arrays / paths of .npz files
+
+        mask : str or Image or None, optional
+            string can be 'compute' or a path to an image
+            image is an input (assumed binary) mask image(s),
+            if 'compute', the mask is computed
+            if None, no masking will be applied
+
+        m, M, threshold: float, optional
+            parameters of the masking procedure.  Should be within [0, 1]
+
+        Notes
+        -----
+        The only computation done here is mask computation (if required)
+
+        """
+        # manipulate the arguments
+        if isinstance(fmri_data, _basestring) or hasattr(fmri_data, 'get_data'):
+            fmri_data = [fmri_data]
+        if isinstance(design_matrices, (_basestring, np.ndarray)):
+            design_matrices = [design_matrices]
+        if len(fmri_data) != len(design_matrices):
+            raise ValueError('Incompatible number of fmri runs and '
+                             'design matrices were provided')
+        self.fmri_data, self.design_matrices = [], []
+        self.glms, self.means = [], []
+
+        # load the fmri data
+        for fmri_run in fmri_data:
+            if isinstance(fmri_run, _basestring):
+                self.fmri_data.append(load(fmri_run))
+            else:
+                self.fmri_data.append(fmri_run)
+
+        # set self.affine as the affine of the first image
+        self.affine = self.fmri_data[0].get_affine()
+
+        # load the designs
+        for design_matrix in design_matrices:
+            if isinstance(design_matrix, _basestring):
+                loaded = np.load(design_matrix)
+                self.design_matrices.append(loaded[loaded.files[0]])
+            else:
+                self.design_matrices.append(design_matrix)
+
+        # load the mask
+        if mask == 'compute':
+            self.mask = compute_mask_sessions(
+                fmri_data, lower_cutoff=m, upper_cutoff=M, connected=True,
+                threshold=threshold, opening=0)
+        elif mask == None:
+            mask = np.ones(self.fmri_data[0].shape[:3]).astype(np.int8)
+            self.mask = Nifti1Image(mask, self.affine)
+        else:
+            if isinstance(mask, _basestring):
+                self.mask = load(mask)
+            else:
+                self.mask = mask
+
+    def fit(self, do_scaling=True, model='ar1', bins=100):
+        """ Load the data, mask the data, scale the data, fit the GLM
+
+        Parameters
+        ----------
+        do_scaling : bool, optional
+            if True, the data should be scaled as pourcent of voxel mean
+
+        model : string, optional,
+            the kind of glm ('ols' or 'ar1') you want to fit to the data
+
+        bins : int, optional
+            in case of an ar1, discretization of the ar1 parameter
+        """
+        # get the mask as an array
+        mask = self.mask.get_data().astype(np.bool)
+
+        self.glms, self.means = [], []
+        for fmri, design_matrix in zip(self.fmri_data, self.design_matrices):
+            if do_scaling:
+                # scale the data
+                data, mean = data_scaling(fmri.get_data()[mask].T)
+            else:
+                data, mean = (fmri.get_data()[mask].T,
+                              fmri.get_data()[mask].T.mean(0))
+            mean_data = mask.astype(np.int16)
+            mean_data[mask] = mean
+            self.means.append(Nifti1Image(mean_data, self.affine))
+            # fit the GLM
+            glm = GeneralLinearModel(design_matrix)
+            glm.fit(data, model, bins)
+            self.glms.append(glm)
+
+    def contrast(self, contrasts, con_id='', contrast_type=None, output_z=True,
+                 output_stat=False, output_effects=False,
+                 output_variance=False):
+        """ Estimation of a contrast as fixed effects on all sessions
+
+        Parameters
+        ----------
+        contrasts : array or list of arrays of shape (n_col) or (n_dim, n_col)
+            where ``n_col`` is the number of columns of the design matrix,
+            numerical definition of the contrast (one array per run)
+
+        con_id : str, optional
+            name of the contrast
+
+        contrast_type : {'t', 'F', 'tmin-conjunction'}, optional
+            type of the contrast
+
+        output_z : bool, optional
+            Return or not the corresponding z-stat image
+
+        output_stat : bool, optional
+            Return or not the base (t/F) stat image
+
+        output_effects : bool, optional
+            Return or not the corresponding effect image
+
+        output_variance : bool, optional
+            Return or not the corresponding variance image
+
+        Returns
+        -------
+        output_images : list of Nifti1Images
+            The desired output images
+        """
+        if self.glms == []:
+            raise ValueError('first run fit() to estimate the model')
+        if isinstance(contrasts, np.ndarray):
+            contrasts = [contrasts]
+        if len(contrasts) != len(self.glms):
+            raise ValueError(
+                'contrasts must be a sequence of %d session contrasts' %
+                len(self.glms))
+
+        contrast_ = None
+        for i, (glm, con) in enumerate(zip(self.glms, contrasts)):
+            if np.all(con == 0):
+                warn('Contrast for session %d is null' % i)
+            elif contrast_ is None:
+                contrast_ = glm.contrast(con, contrast_type)
+            else:
+                contrast_ = contrast_ + glm.contrast(con, contrast_type)
+        if output_z or output_stat:
+            # compute the contrast and stat
+            contrast_.z_score()
+
+        # Prepare the returned images
+        mask = self.mask.get_data().astype(np.bool)
+        do_outputs = [output_z, output_stat, output_effects, output_variance]
+        estimates = ['z_score_', 'stat_', 'effect', 'variance']
+        descrips = ['z statistic', 'Statistical value', 'Estimated effect',
+                    'Estimated variance']
+        dims = [1, 1, contrast_.dim, contrast_.dim ** 2]
+        n_vox = contrast_.z_score_.size
+        output_images = []
+        for (do_output, estimate, descrip, dim) in zip(
+            do_outputs, estimates, descrips, dims):
+            if do_output:
+                if dim > 1:
+                    result_map = np.tile(
+                        mask.astype(np.float)[:, :, :, np.newaxis], dim)
+                    result_map[mask] = np.reshape(
+                        getattr(contrast_, estimate).T, (n_vox, dim))
+                else:
+                    result_map = mask.astype(np.float)
+                    result_map[mask] = np.squeeze(
+                        getattr(contrast_, estimate))
+                output = Nifti1Image(result_map, self.affine)
+                output.get_header()['descrip'] = (
+                    '%s associated with contrast %s' % (descrip, con_id))
+                output_images.append(output)
+        return output_images

--- a/pypreprocess/external/nistats/hemodynamic_models.py
+++ b/pypreprocess/external/nistats/hemodynamic_models.py
@@ -1,0 +1,469 @@
+"""
+This module is for hemodynamic reponse function (hrf) specification.
+Here we provide for SPM, Glover hrfs and finite timpulse response (FIR) models.
+This module closely follows SPM implementation
+
+Author: Bertrand Thirion, 2011--2015
+"""
+
+import warnings
+import numpy as np
+from scipy.stats import gamma
+
+
+def _gamma_difference_hrf(tr, oversampling=16, time_length=32., onset=0.,
+                          delay=6, undershoot=16., dispersion=1.,
+                          u_dispersion=1., ratio=0.167):
+    """ Compute an hrf as the difference of two gamma functions
+
+    Parameters
+    ----------
+
+    tr : float
+        scan repeat time, in seconds
+
+    oversampling : int, optional (default=16)
+        temporal oversampling factor
+
+    time_length : float, optional (default=32)
+        hrf kernel length, in seconds
+
+    onset: float
+        onset time of the hrf
+
+    delay: float, optional
+        delay parameter of the hrf (in s.)
+
+    undershoot: float, optional
+        undershoot parameter of the hrf (in s.)
+
+    dispersion : float, optional
+        dispersion parameter for the first gamma function
+
+    u_dispersion : float, optional
+        dispersion parameter for the second gamma function
+
+    ratio : float, optional
+        ratio of the two gamma components
+
+    Returns
+    -------
+    hrf : array of shape(length / tr * oversampling, dtype=float)
+         hrf sampling on the oversampled time grid
+    """
+    dt = tr / oversampling
+    time_stamps = np.linspace(0, time_length, float(time_length) / dt)
+    time_stamps -= onset / dt
+    hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) - \
+        ratio * gamma.pdf(
+        time_stamps, undershoot / u_dispersion, dt / u_dispersion)
+    hrf /= hrf.sum()
+    return hrf
+
+
+def spm_hrf(tr, oversampling=16, time_length=32., onset=0.):
+    """ Implementation of the SPM hrf model
+
+    Parameters
+    ----------
+    tr : float
+        scan repeat time, in seconds
+
+    oversampling : int, optional
+        temporal oversampling factor
+
+    time_length : float, optional
+        hrf kernel length, in seconds
+
+    onset : float, optional
+        hrf onset time, in seconds
+
+    Returns
+    -------
+    hrf: array of shape(length / tr * oversampling, dtype=float)
+         hrf sampling on the oversampled time grid
+    """
+    return _gamma_difference_hrf(tr, oversampling, time_length, onset)
+
+
+def glover_hrf(tr, oversampling=16, time_length=32., onset=0.):
+    """ Implementation of the Glover hrf model
+
+    Parameters
+    ----------
+    tr : float
+        scan repeat time, in seconds
+
+    oversampling : int, optional
+        temporal oversampling factor
+
+    time_length : float, optional
+        hrf kernel length, in seconds
+
+    onset : float, optional
+        onset of the response
+
+    Returns
+    -------
+    hrf: array of shape(length / tr * oversampling, dtype=float)
+         hrf sampling on the oversampled time grid
+    """
+    return _gamma_difference_hrf(tr, oversampling, time_length, onset,
+                                delay=6, undershoot=12., dispersion=.9,
+                                u_dispersion=.9, ratio=.35)
+
+
+def spm_time_derivative(tr, oversampling=16, time_length=32., onset=0.):
+    """Implementation of the SPM time derivative hrf (dhrf) model
+
+    Parameters
+    ----------
+    tr: float
+        scan repeat time, in seconds
+
+    oversampling: int, optional
+        temporal oversampling factor, optional
+
+    time_length: float, optional
+        hrf kernel length, in seconds
+
+    onset: float, optional
+        onset of the response in seconds
+
+    Returns
+    -------
+    dhrf: array of shape(length / tr, dtype=float)
+          dhrf sampling on the provided grid
+    """
+    do = .1
+    dhrf = 1. / do * (spm_hrf(tr, oversampling, time_length, onset + do) -
+                      spm_hrf(tr, oversampling, time_length, onset))
+    return dhrf
+
+
+def glover_time_derivative(tr, oversampling=16, time_length=32., onset=0.):
+    """Implementation of the Glover time derivative hrf (dhrf) model
+
+    Parameters
+    ----------
+    tr: float
+        scan repeat time, in seconds
+    oversampling: int,
+        temporal oversampling factor, optional
+    time_length: float,
+        hrf kernel length, in seconds
+    onset: float,
+        onset of the response
+
+    Returns
+    -------
+    dhrf: array of shape(length / tr), dtype=float
+          dhrf sampling on the provided grid
+    """
+    do = .1
+    dhrf = 1. / do * (glover_hrf(tr, oversampling, time_length, onset + do) -
+                      glover_hrf(tr, oversampling, time_length, onset))
+    return dhrf
+
+
+def spm_dispersion_derivative(tr, oversampling=16, time_length=32., onset=0.):
+    """Implementation of the SPM dispersion derivative hrf model
+
+    Parameters
+    ----------
+    tr: float
+        scan repeat time, in seconds
+
+    oversampling: int, optional
+        temporal oversampling factor in seconds
+
+    time_length: float, optional
+        hrf kernel length, in seconds
+
+    onset : float, optional
+        onset of the response in seconds
+
+    Returns
+    -------
+    dhrf: array of shape(length / tr * oversampling), dtype=float
+          dhrf sampling on the oversampled time grid
+    """
+    dd = .01
+    dhrf = 1. / dd * (_gamma_difference_hrf(tr, oversampling, time_length,
+                                           onset, dispersion=1. + dd) -
+                      spm_hrf(tr, oversampling, time_length, onset))
+    return dhrf
+
+
+def _sample_condition(exp_condition, frame_times, oversampling=16,
+                     min_onset=-24):
+    """Make a possibly oversampled event regressor from condition information.
+
+    Parameters
+    ----------
+    exp_condition : arraylike of shape (3, n_events)
+        yields description of events for this condition as a
+        (onsets, durations, amplitudes) triplet
+
+    frame_times : array of shape(n_scans)
+        sample time points
+
+    over_sampling : int, optional
+        factor for oversampling event regressor
+
+    min_onset : float, optional
+        minimal onset relative to frame_times[0] (in seconds)
+        events that start before frame_times[0] + min_onset are not considered
+
+    Returns
+    -------
+    regressor: array of shape(over_sampling * n_scans)
+        possibly oversampled event regressor
+    hr_frame_times : array of shape(over_sampling * n_scans)
+        time points used for regressor sampling
+    """
+    # Find the high-resolution frame_times
+    n = frame_times.size
+    min_onset = float(min_onset)
+    n_hr = ((n - 1) * 1. / (frame_times.max() - frame_times.min()) *
+            (frame_times.max() * (1 + 1. / (n - 1)) - frame_times.min() -
+             min_onset) * oversampling) + 1
+
+    hr_frame_times = np.linspace(frame_times.min() + min_onset,
+                                 frame_times.max() * (1 + 1. / (n - 1)), n_hr)
+
+    # Get the condition information
+    onsets, durations, values = tuple(map(np.asanyarray, exp_condition))
+    if (onsets < frame_times[0] + min_onset).any():
+        warnings.warn(('Some stimulus onsets are earlier than %d in the' +
+                       ' experiment and are thus not considered in the model'
+                % (frame_times[0] + min_onset)), UserWarning)
+
+    # Set up the regressor timecourse
+    tmax = len(hr_frame_times)
+    regressor = np.zeros_like(hr_frame_times).astype(np.float)
+    t_onset = np.minimum(np.searchsorted(hr_frame_times, onsets), tmax - 1)
+    regressor[t_onset] += values
+    t_offset = np.minimum(
+        np.searchsorted(hr_frame_times, onsets + durations),
+        tmax - 1)
+
+    # Handle the case where duration is 0 by offsetting at t + 1
+    for i, t in enumerate(t_offset):
+        if t < (tmax - 1) and t == t_onset[i]:
+            t_offset[i] += 1
+
+    regressor[t_offset] -= values
+    regressor = np.cumsum(regressor)
+
+    return regressor, hr_frame_times
+
+
+def _resample_regressor(hr_regressor, hr_frame_times, frame_times):
+    """ this function sub-samples the regressors at frame times
+
+    Parameters
+    ----------
+    hr_regressor : array of shape(n_samples),
+        the regressor time course sampled at high temporal resolution
+
+    hr_frame_times : array of shape(n_samples),
+        the corresponding time stamps
+
+    frame_times: array of shape(n_scans),
+         the desired time stamps
+
+    Returns
+    -------
+    regressor: array of shape(n_scans)
+         the resampled regressor
+    """
+    from scipy.interpolate import interp1d
+    f = interp1d(hr_frame_times, hr_regressor)
+    return f(frame_times).T
+
+
+def _orthogonalize(X):
+    """ Orthogonalize every column of design `X` w.r.t preceding columns
+
+    Parameters
+    ----------
+    X: array of shape(n, p)
+       the data to be orthogonalized
+
+    Returns
+    -------
+    X: array of shape(n, p)
+       the data after orthogonalization
+
+    Notes
+    -----
+    X is changed in place. The columns are not normalized
+    """
+    if X.size == X.shape[0]:
+        return X
+    from scipy.linalg import pinv
+    for i in range(1, X.shape[1]):
+        X[:, i] -= np.dot(X[:, i], np.dot(X[:, :i], pinv(X[:, :i])))
+    return X
+
+
+def _regressor_names(con_name, hrf_model, fir_delays=None):
+    """ Returns a list of regressor names, computed from con-name and hrf type
+
+    Parameters
+    ----------
+    con_name: string
+        identifier of the condition
+
+    hrf_model: string
+       hrf model chosen
+
+    fir_delays: 1D array_like, optional,
+        Delays used in case of an FIR model
+
+    Returns
+    -------
+    names: list of strings,
+        regressor names
+    """
+    if hrf_model == 'canonical':
+        return [con_name]
+    elif hrf_model == "canonical with derivative":
+        return [con_name, con_name + "_derivative"]
+    elif hrf_model == 'spm':
+        return [con_name]
+    elif hrf_model == 'spm_time':
+        return [con_name, con_name + "_derivative"]
+    elif hrf_model == 'spm_time_dispersion':
+        return [con_name, con_name + "_derivative", con_name + "_dispersion"]
+    elif hrf_model == 'fir':
+        return [con_name + "_delay_%d" % i for i in fir_delays]
+
+
+def _hrf_kernel(hrf_model, tr, oversampling=16, fir_delays=None):
+    """ Given the specification of the hemodynamic model and time parameters,
+    return the list of matching kernels
+
+    Parameters
+    ----------
+    hrf_model : string
+        identifier of the hrf model
+
+    tr : float
+        the repetition time in seconds
+
+    oversampling : int, optional
+        temporal oversampling factor to have a smooth hrf
+
+    fir_delays : list of floats,
+        list of delays for finite impulse response models
+
+    Returns
+    -------
+    hkernel : list of arrays
+        samples of the hrf (the number depends on the hrf_model used)
+    """
+    if hrf_model == 'spm':
+        hkernel = [spm_hrf(tr, oversampling)]
+    elif hrf_model == 'spm_time':
+        hkernel = [spm_hrf(tr, oversampling),
+                   spm_time_derivative(tr, oversampling)]
+    elif hrf_model == 'spm_time_dispersion':
+        hkernel = [spm_hrf(tr, oversampling),
+                   spm_time_derivative(tr, oversampling),
+                   spm_dispersion_derivative(tr, oversampling)]
+    elif hrf_model == 'canonical':
+        hkernel = [glover_hrf(tr, oversampling)]
+    elif hrf_model == 'canonical with derivative':
+        hkernel = [glover_hrf(tr, oversampling),
+                   glover_time_derivative(tr, oversampling)]
+    elif hrf_model == 'fir':
+        hkernel = [np.hstack((np.zeros(f * oversampling),
+                              np.ones(oversampling)))
+                   for f in fir_delays]
+    else:
+        raise ValueError('Unknown hrf model')
+    return hkernel
+
+
+def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
+                      oversampling=16, fir_delays=None, min_onset=-24):
+    """ This is the main function to convolve regressors with hrf model
+
+    Parameters
+    ----------
+    exp_condition : arraylike of shape (3, n_events)
+        yields description of events for this condition as a
+        (onsets, durations, amplitudes) triplet
+
+    hrf_model : {'spm', 'spm_time', 'spm_time_dispersion', 'canonical',
+        'canonical_derivative', 'fir'}
+        name of the hrf model to be used
+
+    frame_times : array of shape (n_scans)
+        the desired sampling times
+
+    con_id : string
+        optional identifier of the condition
+
+    oversampling : int, optional
+        oversampling factor to perform the convolution
+
+    fir_delays : 1D-array-like, optional
+        delays (in seconds) used in case of a finite impulse reponse model
+
+    min_onset : float, optional
+        minimal onset relative to frame_times[0] (in seconds)
+        events that start before frame_times[0] + min_onset are not considered
+
+    Returns
+    -------
+    computed_regressors: array of shape(n_scans, n_reg)
+        computed regressors sampled at frame times
+
+    reg_names: list of strings
+        corresponding regressor names
+
+    Notes
+    -----
+    The different hemodynamic models can be understood as follows:
+    'spm': this is the hrf model used in spm
+    'spm_time': this is the spm model plus its time derivative (2 regressors)
+    'spm_time_dispersion': idem, plus dispersion derivative (3 regressors)
+    'canonical': this one corresponds to the Glover hrf
+    'canonical_derivative': the Glover hrf + time derivative (2 regressors)
+    'fir': finite impulse response basis, a set of delayed dirac models
+           with arbitrary length. This one currently assumes regularly spaced
+           frame times (i.e. fixed time of repetition).
+    It is expected that spm standard and Glover model would not yield
+    large differences in most cases.
+
+    In case of canonical and spm models, the derived regressors are
+    orthogonalized wrt the main one.
+    """
+    # this is the average tr in this session, not necessarily the true tr
+    tr = float(frame_times.max()) / (np.size(frame_times) - 1)
+
+    # 1. create the high temporal resolution regressor
+    hr_regressor, hr_frame_times = _sample_condition(
+        exp_condition, frame_times, oversampling, min_onset)
+
+    # 2. create the  hrf model(s)
+    hkernel = _hrf_kernel(hrf_model, tr, oversampling, fir_delays)
+
+    # 3. convolve the regressor and hrf, and downsample the regressor
+    conv_reg = np.array([np.convolve(hr_regressor, h)[:hr_regressor.size]
+                         for h in hkernel])
+
+    # 4. temporally resample the regressors
+    computed_regressors = _resample_regressor(
+        conv_reg, hr_frame_times, frame_times)
+
+    # 5. ortogonalize the regressors
+    if hrf_model != 'fir':
+        computed_regressors = _orthogonalize(computed_regressors)
+
+    # 6 generate regressor names
+    reg_names = _regressor_names(con_id, hrf_model, fir_delays=fir_delays)
+    return computed_regressors, reg_names

--- a/pypreprocess/external/nistats/model.py
+++ b/pypreprocess/external/nistats/model.py
@@ -1,0 +1,362 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+import numpy as np
+from scipy.linalg import inv
+from scipy.stats import t as t_distribution
+
+from nibabel.onetime import setattr_on_read
+
+from .utils import pos_recipr
+
+# Inverse t cumulative distribution
+inv_t_cdf = t_distribution.ppf
+
+class LikelihoodModelResults(object):
+    ''' Class to contain results from likelihood models '''
+
+    # This is the class in which things like AIC, BIC, llf can be implemented as
+    # methods, not computed in, say, the fit method of OLSModel
+
+    def __init__(self, theta, Y, model, cov=None, dispersion=1., nuisance=None,
+                 rank=None):
+        ''' Set up results structure
+
+        Parameters
+        ----------
+        theta : ndarray
+            parameter estimates from estimated model
+
+        Y : ndarray
+            data
+
+        model : ``LikelihoodModel`` instance
+            model used to generate fit
+
+        cov : None or ndarray, optional
+            covariance of thetas
+
+        dispersion : scalar, optional
+            multiplicative factor in front of `cov`
+
+        nuisance : None of ndarray
+            parameter estimates needed to compute logL
+
+        rank : None or scalar
+            rank of the model.  If rank is not None, it is used for df_model
+            instead of the usual counting of parameters.
+
+        Notes
+        -----
+        The covariance of thetas is given by:
+
+            dispersion * cov
+
+        For (some subset of models) `dispersion` will typically be the mean
+        square error from the estimated model (sigma^2)
+        '''
+        self.theta = theta
+        self.Y = Y
+        self.model = model
+        if cov is None:
+            self.cov = self.model.information(self.theta,
+                                              nuisance=self.nuisance)
+        else:
+            self.cov = cov
+        self.dispersion = dispersion
+        self.nuisance = nuisance
+
+        self.df_total = Y.shape[0]
+        self.df_model = model.df_model
+        # put this as a parameter of LikelihoodModel
+        self.df_resid = self.df_total - self.df_model
+
+    @setattr_on_read
+    def logL(self):
+        """
+        The maximized log-likelihood
+        """
+        return self.model.logL(self.theta, self.Y, nuisance=self.nuisance)
+
+    def t(self, column=None):
+        """
+        Return the (Wald) t-statistic for a given parameter estimate.
+
+        Use Tcontrast for more complicated (Wald) t-statistics.
+        """
+
+        if column is None:
+            column = range(self.theta.shape[0])
+
+        column = np.asarray(column)
+        _theta = self.theta[column]
+        _cov = self.vcov(column=column)
+        if _cov.ndim == 2:
+            _cov = np.diag(_cov)
+        _t = _theta * pos_recipr(np.sqrt(_cov))
+        return _t
+
+    def vcov(self, matrix=None, column=None, dispersion=None, other=None):
+        """ Variance/covariance matrix of linear contrast
+
+        Parameters
+        ----------
+        matrix: (dim, self.theta.shape[0]) array, optional
+            numerical contrast specification, where ``dim`` refers to the
+            'dimension' of the contrast i.e. 1 for t contrasts, 1 or more
+            for F contrasts.
+
+        column: int, optional
+            alternative way of specifying contrasts (column index)
+
+        dispersion: float or (n_voxels,) array, optional
+            value(s) for the dispersion parameters
+
+        other: (dim, self.theta.shape[0]) array, optional
+            alternative contrast specification (?)
+
+        Returns
+        -------
+        cov: (dim, dim) or (n_voxels, dim, dim) array
+            the estimated covariance matrix/matrices
+
+        Returns the variance/covariance matrix of a linear contrast of the
+        estimates of theta, multiplied by `dispersion` which will often be an
+        estimate of `dispersion`, like, sigma^2.
+
+        The covariance of interest is either specified as a (set of) column(s)
+        or a matrix.
+        """
+        if self.cov is None:
+            raise ValueError('need covariance of parameters for computing' +\
+                             '(unnormalized) covariances')
+
+        if dispersion is None:
+            dispersion = self.dispersion
+
+        if column is not None:
+            column = np.asarray(column)
+            if column.shape == ():
+                return self.cov[column, column] * dispersion
+            else:
+                return self.cov[column][:, column] * dispersion
+
+        elif matrix is not None:
+            if other is None:
+                other = matrix
+            tmp = np.dot(matrix, np.dot(self.cov, np.transpose(other)))
+            if np.isscalar(dispersion):
+                return tmp * dispersion
+            else:
+                return tmp[:, :, np.newaxis] * dispersion
+        if matrix is None and column is None:
+            return self.cov * dispersion
+
+    def Tcontrast(self, matrix, store=('t', 'effect', 'sd'), dispersion=None):
+        """ Compute a Tcontrast for a row vector `matrix`
+
+        To get the t-statistic for a single column, use the 't' method.
+
+        Parameters
+        ----------
+        matrix : 1D array-like
+            contrast matrix
+
+        store : sequence, optional
+            components of t to store in results output object.  Defaults to all
+            components ('t', 'effect', 'sd').
+
+        dispersion : None or float, optional
+
+        Returns
+        -------
+        res : ``TContrastResults`` object
+        """
+        matrix = np.asarray(matrix)
+        # 1D vectors assumed to be row vector
+        if matrix.ndim == 1:
+            matrix = matrix[None]
+        if matrix.shape[0] != 1:
+            raise ValueError("t contrasts should have only one row")
+        if matrix.shape[1] != self.theta.shape[0]:
+            raise ValueError("t contrasts should be length P=%d, "
+                             "but this is length %d" % (self.theta.shape[0],
+                                                        matrix.shape[1]))
+        store = set(store)
+        if not store.issubset(('t', 'effect', 'sd')):
+            raise ValueError('Unexpected store request in %s' % store)
+        st_t = st_effect = st_sd = effect = sd = None
+        if 't' in store or 'effect' in store:
+            effect = np.dot(matrix, self.theta)
+            if 'effect' in store:
+                st_effect = np.squeeze(effect)
+        if 't' in store or 'sd' in store:
+            sd = np.sqrt(self.vcov(matrix=matrix, dispersion=dispersion))
+            if 'sd' in store:
+                st_sd = np.squeeze(sd)
+        if 't' in store:
+            st_t = np.squeeze(effect * pos_recipr(sd))
+        return TContrastResults(effect=st_effect, t=st_t, sd=st_sd,
+                                df_den=self.df_resid)
+
+    def Fcontrast(self, matrix, dispersion=None, invcov=None):
+        """ Compute an Fcontrast for a contrast matrix `matrix`.
+
+        Here, `matrix` M is assumed to be non-singular. More precisely
+
+        .. math::
+
+            M pX pX' M'
+
+        is assumed invertible. Here, :math:`pX` is the generalized inverse of
+        the design matrix of the model. There can be problems in non-OLS models
+        where the rank of the covariance of the noise is not full.
+
+        See the contrast module to see how to specify contrasts.  In particular,
+        the matrices from these contrasts will always be non-singular in the
+        sense above.
+
+        Parameters
+        ----------
+        matrix : 1D array-like
+            contrast matrix
+
+        dispersion : None or float, optional
+            If None, use ``self.dispersion``
+
+        invcov : None or array, optional
+            Known inverse of variance covariance matrix.
+            If None, calculate this matrix.
+
+        Returns
+        -------
+        f_res : ``FContrastResults`` instance
+            with attributes F, df_den, df_num
+
+        Notes
+        -----
+        For F contrasts, we now specify an effect and covariance
+        """
+        matrix = np.asarray(matrix)
+        # 1D vectors assumed to be row vector
+        if matrix.ndim == 1:
+            matrix = matrix[None]
+        if matrix.shape[1] != self.theta.shape[0]:
+            raise ValueError("F contrasts should have shape[1] P=%d, "
+                             "but this has shape[1] %d" % (self.theta.shape[0],
+                                                           matrix.shape[1]))
+        ctheta = np.dot(matrix, self.theta)
+        if matrix.ndim == 1:
+            matrix = matrix.reshape((1, matrix.shape[0]))
+        if dispersion is None:
+            dispersion = self.dispersion
+        q = matrix.shape[0]
+        if invcov is None:
+            invcov = inv(self.vcov(matrix=matrix, dispersion=1.0))
+        F = np.add.reduce(np.dot(invcov, ctheta) * ctheta, 0) *\
+            pos_recipr((q * dispersion))
+        F = np.squeeze(F)
+        return FContrastResults(
+            effect=ctheta, covariance=self.vcov(
+                matrix=matrix, dispersion=dispersion[np.newaxis]),
+            F=F, df_den=self.df_resid, df_num=invcov.shape[0])
+
+    def conf_int(self, alpha=.05, cols=None, dispersion=None):
+        ''' The confidence interval of the specified theta estimates.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            The `alpha` level for the confidence interval.
+            ie., `alpha` = .05 returns a 95% confidence interval.
+
+        cols : tuple, optional
+            `cols` specifies which confidence intervals to return
+
+        dispersion : None or scalar
+            scale factor for the variance / covariance (see class docstring and
+            ``vcov`` method docstring)
+
+        Returns
+        -------
+        cis : ndarray
+            `cis` is shape ``(len(cols), 2)`` where each row contains [lower,
+            upper] for the given entry in `cols`
+
+        Examples
+        --------
+        >>> from numpy.random import standard_normal as stan
+        >>> from nistats.regression import OLSModel
+        >>> x = np.hstack((stan((30,1)),stan((30,1)),stan((30,1))))
+        >>> beta=np.array([3.25, 1.5, 7.0])
+        >>> y = np.dot(x,beta) + stan((30))
+        >>> model = OLSModel(x).fit(y)
+        >>> confidence_intervals = model.conf_int(cols=(1,2))
+
+        Notes
+        -----
+        Confidence intervals are two-tailed.
+        TODO:
+        tails : string, optional
+            `tails` can be "two", "upper", or "lower"
+        '''
+        if cols is None:
+            lower = self.theta - inv_t_cdf(1 - alpha / 2, self.df_resid) *\
+                    np.sqrt(np.diag(self.vcov(dispersion=dispersion)))
+            upper = self.theta + inv_t_cdf(1 - alpha / 2, self.df_resid) *\
+                    np.sqrt(np.diag(self.vcov(dispersion=dispersion)))
+        else:
+            lower, upper = [], []
+            for i in cols:
+                lower.append(
+                    self.theta[i] - inv_t_cdf(1 - alpha / 2, self.df_resid) *
+                    np.sqrt(self.vcov(column=i, dispersion=dispersion)))
+                upper.append(
+                    self.theta[i] + inv_t_cdf(1 - alpha / 2, self.df_resid) *
+                    np.sqrt(self.vcov(column=i, dispersion=dispersion)))
+        return np.asarray(list(zip(lower, upper)))
+
+
+class TContrastResults(object):
+    """ Results from a t contrast of coefficients in a parametric model.
+
+    The class does nothing, it is a container for the results from T contrasts,
+    and returns the T-statistics when np.asarray is called.
+    """
+
+    def __init__(self, t, sd, effect, df_den=None):
+        if df_den is None:
+            df_den = np.inf
+        self.t = t
+        self.sd = sd
+        self.effect = effect
+        self.df_den = df_den
+
+    def __array__(self):
+        return np.asarray(self.t)
+
+    def __str__(self):
+        return ('<T contrast: effect=%s, sd=%s, t=%s, df_den=%d>' %
+                (self.effect, self.sd, self.t, self.df_den))
+
+
+class FContrastResults(object):
+    """ Results from an F contrast of coefficients in a parametric model.
+
+    The class does nothing, it is a container for the results from F contrasts,
+    and returns the F-statistics when np.asarray is called.
+    """
+
+    def __init__(self, effect, covariance, F, df_num, df_den=None):
+        if df_den is None:
+            df_den = np.inf
+        self.effect = effect
+        self.covariance = covariance
+        self.F = F
+        self.df_den = df_den
+        self.df_num = df_num
+    def __array__(self):
+        return np.asarray(self.F)
+
+    def __str__(self):
+        return '<F contrast: F=%s, df_den=%d, df_num=%d>' % \
+            (repr(self.F), self.df_den, self.df_num)

--- a/pypreprocess/external/nistats/model.py
+++ b/pypreprocess/external/nistats/model.py
@@ -285,7 +285,7 @@ class LikelihoodModelResults(object):
         Examples
         --------
         >>> from numpy.random import standard_normal as stan
-        >>> from nistats.regression import OLSModel
+        >>> from pypreprocess.external.nistats.regression import OLSModel
         >>> x = np.hstack((stan((30,1)),stan((30,1)),stan((30,1))))
         >>> beta=np.array([3.25, 1.5, 7.0])
         >>> y = np.dot(x,beta) + stan((30))

--- a/pypreprocess/external/nistats/regression.py
+++ b/pypreprocess/external/nistats/regression.py
@@ -1,0 +1,329 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+This module implements some standard regression models: OLS and WLS
+models, as well as an AR(p) regression model.
+
+Models are specified with a design matrix and are fit using their
+'fit' method.
+
+Subclasses that have more complicated covariance matrices
+should write over the 'whiten' method as the fit method
+prewhitens the response by calling 'whiten'.
+
+General reference for regression models:
+
+'Introduction to Linear Regression Analysis', Douglas C. Montgomery,
+    Elizabeth A. Peck, G. Geoffrey Vining. Wiley, 2006.
+
+"""
+
+__docformat__ = 'restructuredtext en'
+
+import warnings
+
+import numpy as np
+import scipy.linalg as spl
+from scipy import stats
+
+from nibabel.onetime import setattr_on_read
+
+from .utils import matrix_rank, pos_recipr
+
+from .model import LikelihoodModelResults
+
+
+class OLSModel(object):
+    """ A simple ordinary least squares model.
+
+    Parameters
+    ----------
+    design : array-like
+        This is your design matrix.  Data are assumed to be column ordered with
+        observations in rows.
+
+    Methods
+    -------
+    model.__init___(design)
+    model.logL(b=self.beta, Y)
+
+    Attributes
+    ----------
+    design : ndarray
+        This is the design, or X, matrix.
+
+    wdesign : ndarray
+        This is the whitened design matrix.  `design` == `wdesign` by default
+        for the OLSModel, though models that inherit from the OLSModel will
+        whiten the design.
+
+    calc_beta : ndarray
+        This is the Moore-Penrose pseudoinverse of the whitened design matrix.
+
+    normalized_cov_beta : ndarray
+        ``np.dot(calc_beta, calc_beta.T)``
+
+    df_resid : scalar
+        Degrees of freedom of the residuals.  Number of observations less the
+        rank of the design.
+
+    df_model : scalar
+        Degrees of freedome of the model.  The rank of the design.
+    """
+
+    def __init__(self, design):
+        """
+        Parameters
+        ----------
+        design : array-like
+            This is your design matrix.
+            Data are assumed to be column ordered with
+            observations in rows.
+        """
+        super(OLSModel, self).__init__()
+        self.initialize(design)
+
+    def initialize(self, design):
+        # PLEASE don't assume we have a constant...
+        # TODO: handle case for noconstant regression
+        self.design = design
+        self.wdesign = self.whiten(self.design)
+        self.calc_beta = spl.pinv(self.wdesign)
+        self.normalized_cov_beta = np.dot(self.calc_beta,
+                                          np.transpose(self.calc_beta))
+        self.df_total = self.wdesign.shape[0]
+        self.df_model = matrix_rank(self.design)
+        self.df_resid = self.df_total - self.df_model
+
+    def logL(self, beta, Y, nuisance=None):
+        r''' Returns the value of the loglikelihood function at beta.
+
+        Given the whitened design matrix, the loglikelihood is evaluated
+        at the parameter vector, beta, for the dependent variable, Y
+        and the nuisance parameter, sigma.
+
+        Parameters
+        ----------
+        beta : ndarray
+            The parameter estimates.  Must be of length df_model.
+
+        Y : ndarray
+            The dependent variable
+
+        nuisance : dict, optional
+            A dict with key 'sigma', which is an optional estimate of sigma. If
+            None, defaults to its maximum likelihood estimate (with beta fixed)
+            as ``sum((Y - X*beta)**2) / n``, where n=Y.shape[0], X=self.design.
+
+        Returns
+        -------
+        loglf : float
+            The value of the loglikelihood function.
+
+        Notes
+        -----
+        The log-Likelihood Function is defined as
+
+        .. math::
+
+            \ell(\beta,\sigma,Y)=
+            -\frac{n}{2}\log(2\pi\sigma^2) - \|Y-X\beta\|^2/(2\sigma^2)
+
+        The parameter :math:`\sigma` above is what is sometimes referred to as a
+        nuisance parameter. That is, the likelihood is considered as a function
+        of :math:`\beta`, but to evaluate it, a value of :math:`\sigma` is
+        needed.
+
+        If :math:`\sigma` is not provided, then its maximum likelihood estimate:
+
+        .. math::
+
+            \hat{\sigma}(\beta) = \frac{\text{SSE}(\beta)}{n}
+
+        is plugged in. This likelihood is now a function of only :math:`\beta`
+        and is technically referred to as a profile-likelihood.
+
+        References
+        ----------
+        .. [1] W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
+        '''
+        # This is overwriting an abstract method of LikelihoodModel
+        X = self.wdesign
+        wY = self.whiten(Y)
+        r = wY - np.dot(X, beta)
+        n = self.df_total
+        SSE = (r ** 2).sum(0)
+        if nuisance is None:
+            sigmasq = SSE / n
+        else:
+            sigmasq = nuisance['sigma']
+        loglf = - n / 2. * np.log(2 * np.pi * sigmasq) - SSE / (2 * sigmasq)
+        return loglf
+
+    def whiten(self, X):
+        """ Whiten design matrix
+
+        Parameters
+        ----------
+        X : array
+            design matrix
+
+        Returns
+        -------
+        wX : array
+            This matrix is the matrix whose pseudoinverse is ultimately
+            used in estimating the coefficients. For OLSModel, it is
+            does nothing. For WLSmodel, ARmodel, it pre-applies
+            a square root of the covariance matrix to X.
+        """
+        return X
+
+    def fit(self, Y):
+        """ Fit model to data `Y`
+
+        Full fit of the model including estimate of covariance matrix,
+        (whitened) residuals and scale.
+
+        Parameters
+        ----------
+        Y : array-like
+            The dependent variable for the Least Squares problem.
+
+        Returns
+        -------
+        fit : RegressionResults
+        """
+        # Other estimates of the covariance matrix for a heteroscedastic
+        # regression model can be implemented in WLSmodel. (Weighted least
+        # squares models assume covariance is diagonal, i.e. heteroscedastic).
+        wY = self.whiten(Y)
+        beta = np.dot(self.calc_beta, wY)
+        wresid = wY - np.dot(self.wdesign, beta)
+        dispersion = np.sum(wresid ** 2, 0) / (self.wdesign.shape[0] -
+                                                self.wdesign.shape[1])
+        lfit = RegressionResults(beta, Y, self,
+                                 wY, wresid, dispersion=dispersion,
+                                 cov=self.normalized_cov_beta)
+        return lfit
+
+
+class ARModel(OLSModel):
+    """ A regression model with an AR(p) covariance structure.
+
+    In terms of a LikelihoodModel, the parameters
+    are beta, the usual regression parameters,
+    and sigma, a scalar nuisance parameter that
+    shows up as multiplier in front of the AR(p) covariance.
+
+    """
+
+    def __init__(self, design, rho):
+        """ Initialize AR model instance
+
+        Parameters
+        ----------
+        design : ndarray
+            2D array with design matrix
+        rho : int or array-like
+            If int, gives order of model, and initializes rho to zeros.  If
+            ndarray, gives initial estimate of rho. Be careful as ``ARModel(X,
+            1) != ARModel(X, 1.0)``.
+        """
+        if type(rho) is type(1):
+            self.order = rho
+            self.rho = np.zeros(self.order, np.float64)
+        else:
+            self.rho = np.squeeze(np.asarray(rho))
+            if len(self.rho.shape) not in [0, 1]:
+                raise ValueError("AR parameters must be a scalar or a vector")
+            if self.rho.shape == ():
+                self.rho.shape = (1,)
+            self.order = self.rho.shape[0]
+        super(ARModel, self).__init__(design)
+
+
+    def whiten(self, X):
+        """ Whiten a series of columns according to AR(p) covariance structure
+
+        Parameters
+        ----------
+        X : array-like of shape (n_features)
+            array to whiten
+
+        Returns
+        -------
+        wX : ndarray
+            X whitened with order self.order AR
+        """
+        X = np.asarray(X, np.float64)
+        _X = X.copy()
+        for i in range(self.order):
+            _X[(i + 1):] = _X[(i + 1):] - self.rho[i] * X[0: - (i + 1)]
+        return _X
+
+
+class RegressionResults(LikelihoodModelResults):
+    """
+    This class summarizes the fit of a linear regression model.
+
+    It handles the output of contrasts, estimates of covariance, etc.
+    """
+
+    def __init__(self, theta, Y, model, wY, wresid, cov=None, dispersion=1.,
+                 nuisance=None):
+        """See LikelihoodModelResults constructor.
+
+        The only difference is that the whitened Y and residual values
+        are stored for a regression model.
+        """
+        LikelihoodModelResults.__init__(self, theta, Y, model, cov,
+                                        dispersion, nuisance)
+        self.wY = wY
+        self.wresid = wresid
+
+    @setattr_on_read
+    def resid(self):
+        """
+        Residuals from the fit.
+        """
+        return self.Y - self.predicted
+
+    @setattr_on_read
+    def norm_resid(self):
+        """
+        Residuals, normalized to have unit length.
+
+        Notes
+        -----
+        Is this supposed to return "stanardized residuals,"
+        residuals standardized
+        to have mean zero and approximately unit variance?
+
+        d_i = e_i / sqrt(MS_E)
+
+        Where MS_E = SSE / (n - k)
+
+        See: Montgomery and Peck 3.2.1 p. 68
+             Davidson and MacKinnon 15.2 p 662
+        """
+        return self.resid * pos_recipr(np.sqrt(self.dispersion))
+
+    @setattr_on_read
+    def predicted(self):
+        """ Return linear predictor values from a design matrix.
+        """
+        beta = self.theta
+        # the LikelihoodModelResults has parameters named 'theta'
+        X = self.model.design
+        return np.dot(X, beta)
+
+    @setattr_on_read
+    def SSE(self):
+        """Error sum of squares. If not from an OLS model this is "pseudo"-SSE.
+        """
+        return (self.wresid ** 2).sum(0)
+
+    @setattr_on_read
+    def MSE(self):
+        """ Mean square (error) """
+        return self.SSE / self.df_resid

--- a/pypreprocess/external/nistats/utils.py
+++ b/pypreprocess/external/nistats/utils.py
@@ -1,0 +1,241 @@
+""" Misc utilities for the library
+
+Authors: Bertrand Thirion, Matthew Brett, 2015
+"""
+import sys
+import scipy.linalg as spl
+import numpy as np
+from scipy.stats import norm
+
+py3 = sys.version_info[0] >= 3
+
+
+def z_score(pvalue):
+    """ Return the z-score corresponding to a given p-value.
+    """
+    pvalue = np.minimum(np.maximum(pvalue, 1.e-300), 1. - 1.e-16)
+    return norm.isf(pvalue)
+
+
+def multiple_fast_inv(a):
+    """Compute the inverse of a set of arrays.
+
+    Parameters
+    ----------
+    a: array_like of shape (n_samples, n_dim, n_dim)
+        Set of square matrices to be inverted. A is changed in place.
+
+    Returns
+    -------
+    a: ndarray
+       yielding the inverse of the inputs
+
+    Raises
+    ------
+    LinAlgError :
+        If `a` is singular.
+    ValueError :
+        If `a` is not square, or not 2-dimensional.
+
+    Notes
+    -----
+    This function is borrowed from scipy.linalg.inv, 
+    but with some customizations for speed-up.
+    """
+    if a.shape[1] != a.shape[2]:
+        raise ValueError('a must have shape(n_samples, n_dim, n_dim)')
+    from scipy.linalg import calc_lwork
+    from scipy.linalg.lapack import  get_lapack_funcs
+    a1, n = a[0], a.shape[0]
+    getrf, getri = get_lapack_funcs(('getrf', 'getri'), (a1,))
+    for i in range(n):
+        if (getrf.module_name[:7] == 'clapack'
+            and getri.module_name[:7] != 'clapack'):
+            # ATLAS 3.2.1 has getrf but not getri.
+            lu, piv, info = getrf(np.transpose(a[i]), rowmajor=0,
+                                  overwrite_a=True)
+            a[i] = np.transpose(lu)
+        else:
+            a[i], piv, info = getrf(a[i], overwrite_a=True)
+        if info == 0:
+            if getri.module_name[:7] == 'flapack':
+                lwork = calc_lwork.getri(getri.prefix, a1.shape[0])
+                lwork = lwork[1]
+                # XXX: the following line fixes curious SEGFAULT when
+                # benchmarking 500x500 matrix inverse. This seems to
+                # be a bug in LAPACK ?getri routine because if lwork is
+                # minimal (when using lwork[0] instead of lwork[1]) then
+                # all tests pass. Further investigation is required if
+                # more such SEGFAULTs occur.
+                lwork = int(1.01 * lwork)
+                a[i], _ = getri(a[i], piv, lwork=lwork, overwrite_lu=1)
+            else:  # clapack
+                a[i], _ = getri(a[i], piv, overwrite_lu=1)
+        else:
+            raise ValueError('Matrix LU decomposition failed')
+    return a
+
+
+def multiple_mahalanobis(effect, covariance):
+    """Returns the squared Mahalanobis distance for a given set of samples
+    
+    Parameters
+    ----------
+    effect: array of shape (n_features, n_samples),
+        Each column represents a vector to be evaluated
+
+    covariance: array of shape (n_features, n_features, n_samples),
+        Corresponding covariance models stacked along the last axis
+
+    Returns
+    -------
+    sqd: array of shape (n_samples,)
+         the squared distances (one per sample)
+    """ 
+    # check size
+    if effect.ndim == 1:
+        effect = effect[:, np.newaxis]
+    if covariance.ndim == 2:
+        covariance = covariance[:, :, np.newaxis]
+    if effect.shape[0] != covariance.shape[0]:
+        raise ValueError('Inconsistant shape for effect and covariance')
+    if covariance.shape[0] != covariance.shape[1]:
+        raise ValueError('Inconsistant shape for covariance')
+
+    # transpose and make contuguous for the sake of speed
+    Xt, Kt = np.ascontiguousarray(effect.T), np.ascontiguousarray(covariance.T)
+
+    # compute the inverse of the covariances
+    Kt = multiple_fast_inv(Kt)
+
+    # derive the squared Mahalanobis distances
+    sqd = np.sum(np.sum(Xt[:, :, np.newaxis] * Xt[:, np.newaxis] * Kt, 1), 1)
+    return sqd
+
+
+def matrix_rank(M, tol=None):
+    ''' Return rank of matrix using SVD method
+
+    Rank of the array is the number of SVD singular values of the
+    array that are greater than `tol`.
+
+    This version of matrix rank is very similar to the numpy.linalg version
+    except for the use of:
+
+    * scipy.linalg.svd istead of numpy.linalg.svd.
+    * the MATLAB algorithm for default tolerance calculation
+
+    ``matrix_rank`` appeared in numpy.linalg in December 2009, first available
+    in numpy 1.5.0.
+
+    Parameters
+    ----------
+    M : array-like
+        array of <=2 dimensions
+    tol : {None, float}
+         threshold below which SVD values are considered zero. If `tol`
+         is None, and `S` is an array with singular values for `M`, and
+         `eps` is the epsilon value for datatype of `S`, then `tol` set
+         to ``S.max() * eps * max(M.shape)``.
+
+    Examples
+    --------
+    >>> matrix_rank(np.eye(4)) # Full rank matrix
+    4
+    >>> I=np.eye(4); I[-1,-1] = 0. # rank deficient matrix
+    >>> matrix_rank(I)
+    3
+    >>> matrix_rank(np.zeros((4,4))) # All zeros - zero rank
+    0
+    >>> matrix_rank(np.ones((4,))) # 1 dimension - rank 1 unless all 0
+    1
+    >>> matrix_rank(np.zeros((4,)))
+    0
+    >>> matrix_rank([1]) # accepts array-like
+    1
+
+    Notes
+    -----
+    We check for numerical rank deficiency by using ``tol=max(M.shape) * eps *
+    S[0]`` (where ``S[0]`` is the maximum singular value and thus the 2-norm of
+    the matrix). This is one tolerance threshold for rank deficiency, and the
+    default algorithm used by MATLAB [#2]_.  When floating point roundoff is the
+    main concern, then "numerical rank deficiency" is a reasonable choice. In
+    some cases you may prefer other definitions. The most useful measure of the
+    tolerance depends on the operations you intend to use on your matrix. For
+    example, if your data come from uncertain measurements with uncertainties
+    greater than floating point epsilon, choosing a tolerance near that
+    uncertainty may be preferable.  The tolerance may be absolute if the
+    uncertainties are absolute rather than relative.
+
+    References
+    ----------
+    .. [#1] G. H. Golub and C. F. Van Loan, _Matrix Computations_.
+    Baltimore: Johns Hopkins University Press, 1996.
+    .. [#2] http://www.mathworks.com/help/techdoc/ref/rank.html
+    '''
+    M = np.asarray(M)
+    if M.ndim > 2:
+        raise TypeError('array should have 2 or fewer dimensions')
+    if M.ndim < 2:
+        return int(not np.all(M == 0))
+    S = spl.svd(M, compute_uv=False)
+    if tol is None:
+        tol = S.max() * np.finfo(S.dtype).eps * max(M.shape)
+    return np.sum(S > tol)
+
+
+def full_rank(X, r=None):
+    """ Return full-rank matrix whose column span is the same as X
+
+    Uses an SVD decomposition.
+
+    If the rank of `X` is known it can be specified by `r` -- no check is made
+    to ensure that this really is the rank of X.
+
+    Parameters
+    ----------
+    X : array-like
+        2D array which may not be of full rank.
+    r : None or int
+        Known rank of `X`.  r=None results in standard matrix rank calculation.
+        We do not check `r` is really the rank of X; it is to speed up
+        calculations when the rank is already known.
+
+    Returns
+    -------
+    fX : array
+        Full-rank matrix with column span matching that of `X`
+    """
+    if r is None:
+        r = matrix_rank(X)
+    V, D, U = spl.svd(X, full_matrices=0)
+    order = np.argsort(D)
+    order = order[::-1]
+    value = []
+    for i in range(r):
+        value.append(V[:, order[i]])
+    return np.asarray(value).T.astype(np.float64)
+
+
+def pos_recipr(X):
+    """ Return element-wise reciprocal of array, setting `X`>=0 to 0
+
+    Return the reciprocal of an array, setting all entries less than or
+    equal to 0 to 0. Therefore, it presumes that X should be positive in
+    general.
+
+    Parameters
+    ----------
+    X : array-like
+
+    Returns
+    -------
+    rX : array
+       array of same shape as `X`, dtype np.float, with values set to
+       1/X where X > 0, 0 otherwise
+    """
+    X = np.asarray(X)
+    return np.where(X <= 0, 0, 1. / X)
+
+_basestring = str if py3 else basestring

--- a/pypreprocess/fsl_to_nipy.py
+++ b/pypreprocess/fsl_to_nipy.py
@@ -9,8 +9,8 @@ into nipy format (mainly numpy arrays).
 import os
 import re
 import numpy as np
-from nipy.modalities.fmri.experimental_paradigm import BlockParadigm
-from nipy.modalities.fmri.design_matrix import make_dmtx
+from external.nistats.design_matrix import make_design_matrix
+from pandas import DataFrame
 
 # regex for contrasts
 CON_REAL_REGX = ("set fmri\(con_real(?P<con_num>\d+?)\.(?P<ev_num>\d+?)\)"
@@ -117,12 +117,12 @@ def read_fsl_design_file(design_filename):
 
     # lookup EV titles
     conditions = [item.group("evtitle") for item in re.finditer(
-            EV_TITLE_REGX, design_conf)]
+                  EV_TITLE_REGX, design_conf)]
     assert len(conditions) == n_conditions_orig
 
     # lookup contrast titles
     contrast_ids = [item.group("conname_real")for item in re.finditer(
-            CON_TITLE_REGX, design_conf)]
+                    CON_TITLE_REGX, design_conf)]
     assert len(contrast_ids) == n_contrasts
 
     # # lookup EV (condition) shapes
@@ -199,8 +199,10 @@ def make_paradigm_from_timing_files(timing_files, condition_ids=None):
                 "the onsets, the second for the durations, and the "
                 "third --if present-- if for the amplitudes; got %s" % timing)
 
-    return BlockParadigm(con_id=_condition_ids, onset=onsets,
-                         duration=durations, amplitude=amplitudes)
+    return DataFrame({'name': condition_ids,
+                      'onset': onsets,
+                      'duration': durations,
+                      'modulation': amplitudes})
 
 
 def make_dmtx_from_timing_files(timing_files, condition_ids=None,
@@ -248,7 +250,9 @@ def make_dmtx_from_timing_files(timing_files, condition_ids=None,
         make_dmtx_kwargs["add_regs"] = add_regs
 
     # make design matrix
-    design_matrix = make_dmtx(frametimes, paradigm, **make_dmtx_kwargs)
+    design_matrix = make_design_matrix(frame_times=frametimes,
+                                       paradigm=paradigm,
+                                       **make_dmtx_kwargs)
 
     # return output
     return design_matrix, paradigm, frametimes

--- a/pypreprocess/fsl_to_nistats.py
+++ b/pypreprocess/fsl_to_nistats.py
@@ -1,7 +1,7 @@
 """
-:Module: fsl_to_nipy
+:Module: fsl_to_nistats
 :Synopsis: Utility script for converting FSL configuration (design, etc.) files
-into nipy format (mainly numpy arrays).
+into Dataframe format.
 :Author: DOHMATOB Elvis Dopgima <gmdopp@gmail.com> <elvis.dohmatob@inria.fr>
 
 """

--- a/pypreprocess/fsl_to_nistats.py
+++ b/pypreprocess/fsl_to_nistats.py
@@ -9,7 +9,7 @@ into nipy format (mainly numpy arrays).
 import os
 import re
 import numpy as np
-from external.nistats.design_matrix import make_design_matrix
+from pypreprocess.external.nistats.design_matrix import make_design_matrix
 from pandas import DataFrame
 
 # regex for contrasts

--- a/pypreprocess/fsl_to_nistats.py
+++ b/pypreprocess/fsl_to_nistats.py
@@ -10,7 +10,7 @@ import os
 import re
 import numpy as np
 from pypreprocess.external.nistats.design_matrix import make_design_matrix
-from pandas import DataFrame
+import pandas as pd
 
 # regex for contrasts
 CON_REAL_REGX = ("set fmri\(con_real(?P<con_num>\d+?)\.(?P<ev_num>\d+?)\)"
@@ -199,10 +199,10 @@ def make_paradigm_from_timing_files(timing_files, condition_ids=None):
                 "the onsets, the second for the durations, and the "
                 "third --if present-- if for the amplitudes; got %s" % timing)
 
-    return DataFrame({'name': condition_ids,
-                      'onset': onsets,
-                      'duration': durations,
-                      'modulation': amplitudes})
+    return pd.DataFrame({'name': condition_ids,
+                         'onset': onsets,
+                         'duration': durations,
+                         'modulation': amplitudes})
 
 
 def make_dmtx_from_timing_files(timing_files, condition_ids=None,

--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -625,7 +625,6 @@ def _do_subject_segment(subject_data, output_modulated_tpms=True, spm_dir=None,
         gm_output_type = [output_modulated_tpms, True, True]
         wm_output_type = [output_modulated_tpms, True, True]
         csf_output_type = [output_modulated_tpms, True, True]
-
     # run node
     segment_result = segment(
         data=subject_data.anat,

--- a/pypreprocess/reporting/base_reporter.py
+++ b/pypreprocess/reporting/base_reporter.py
@@ -26,7 +26,7 @@ PYPREPROCESS_URL = "https://github.com/neurospin/pypreprocess"
 DARTEL_URL = ("http://www.fil.ion.ucl.ac.uk/spm/software/spm8/"
               "SPM8_Release_Notes.pdf")
 NIPYPE_URL = "http://nipy.sourceforge.net/nipype/"
-
+NISTATS_URL = "https://github.com/nistats/nistats"
 
 def lines2breaks(lines, delimiter="\n", number_lines=False):
     """
@@ -435,8 +435,8 @@ def make_standalone_colorbar(cmap, vmin, vmax, colorbar_outfile=None):
 
     Parameters
     ----------
-    cmap: some colormap object (like pylab.cm.hot, et
-    nipy.lab.viz.cold_hot, etc.)
+    cmap: some colormap object (like pylab.cm.hot,
+     nilearn.plotting.cm.cold_hot, etc.)
         colormap to use in plotting colorbar
     vmin: float
         param passed to `mpl.colors.Normalize`

--- a/pypreprocess/reporting/check_preprocessing.py
+++ b/pypreprocess/reporting/check_preprocessing.py
@@ -1,7 +1,7 @@
 """
 :Module: check_preprocessing
 :Synopsis: module for generating post-preproc plots (registration,
-segmentation, etc.) using the viz module from nipy.labs.
+segmentation, etc.)
 :Author: bertrand thirion, dohmatob elvis dopgima
 
 """
@@ -78,7 +78,7 @@ def plot_registration(reference_img, coregistered_img,
         path to other image (to be compared with reference)
 
     display_mode: string (optional, defaults to 'ortho')
-        display_mode param to pass to the nipy.labs.viz.plot_??? APIs
+        display_mode param
 
     cmap: matplotlib colormap object (optional, defaults to spectral)
         colormap to user for plots

--- a/pypreprocess/reporting/glm_reporter.py
+++ b/pypreprocess/reporting/glm_reporter.py
@@ -259,6 +259,13 @@ powered by <a href="%s">nistats</a>.""" % (user_script_name,
                     " specifying the experimental paradigm and fitting the "
                     "GLM:<br/><ul>")
 
+        # reshape glm_kwargs['paradigm']
+        paradigm = glm_kwargs['paradigm'].to_dict('list')
+        paradigm['n_conditions'] = len(set(paradigm['name']))
+        paradigm['n_events'] = len(paradigm['name'])
+        paradigm['type'] = 'block' if paradigm['duration'][0] > 0 else 'event'
+        glm_kwargs['paradigm'] = paradigm
+
         design_params += base_reporter.dict_to_html_ul(glm_kwargs)
 
     if start_time is None:

--- a/pypreprocess/reporting/glm_reporter.py
+++ b/pypreprocess/reporting/glm_reporter.py
@@ -263,7 +263,9 @@ powered by <a href="%s">nistats</a>.""" % (user_script_name,
         paradigm = glm_kwargs['paradigm'].to_dict('list')
         paradigm['n_conditions'] = len(set(paradigm['name']))
         paradigm['n_events'] = len(paradigm['name'])
-        paradigm['type'] = 'block' if paradigm['duration'][0] > 0 else 'event'
+        paradigm['type'] = 'event'
+        if 'duration' in paradigm.keys() and paradigm['duration'][0] > 0:
+            paradigm['type'] = 'block'
         glm_kwargs['paradigm'] = paradigm
 
         design_params += base_reporter.dict_to_html_ul(glm_kwargs)

--- a/pypreprocess/reporting/glm_reporter.py
+++ b/pypreprocess/reporting/glm_reporter.py
@@ -5,8 +5,8 @@ import pylab as pl
 import nibabel
 from nilearn.plotting import plot_stat_map
 from nilearn.image import reorder_img
-from ..external.nistats.design_matrix import plot_design_matrix
-from ..external.nistats.glm import FMRILinearModel
+from pypreprocess.external.nistats.design_matrix import plot_design_matrix
+from pypreprocess.external.nistats.glm import FMRILinearModel
 from pandas import DataFrame, read_pickle
 from nilearn.masking import intersect_masks
 import base_reporter

--- a/pypreprocess/reporting/glm_reporter.py
+++ b/pypreprocess/reporting/glm_reporter.py
@@ -5,8 +5,10 @@ import pylab as pl
 import nibabel
 from nilearn.plotting import plot_stat_map
 from nilearn.image import reorder_img
-from nipy.modalities.fmri.glm import FMRILinearModel
-from nipy.labs.mask import intersect_masks
+from ..external.nistats.design_matrix import plot_design_matrix
+from ..external.nistats.glm import FMRILinearModel
+from pandas import DataFrame, read_pickle
+from nilearn.masking import intersect_masks
 import base_reporter
 from ..cluster_level_analysis import cluster_stats
 
@@ -215,9 +217,6 @@ def generate_subject_stats_report(
         experimental paradigm and the GLM
 
     """
-    # Delayed import of nipy for more robustness when it is not present
-    from nipy.modalities.fmri.design_matrix import DesignMatrix
-
     # prepare for stats reporting
     if progress_logger is None:
         progress_logger = base_reporter.ProgressReport()
@@ -249,8 +248,8 @@ def generate_subject_stats_report(
 
     methods = """
     GLM and Statistical Inference have been done using the <i>%s</i> script, \
-powered by <a href="%s">nipy</a>.""" % (user_script_name,
-                                       base_reporter.NIPY_URL)
+powered by <a href="%s">nistats</a>.""" % (user_script_name,
+                                           base_reporter.NISTATS_URL)
 
     # report the control parameters used in the paradigm and analysis
     design_params = ""
@@ -281,7 +280,7 @@ powered by <a href="%s">nipy</a>.""" % (user_script_name,
 
         design_params=design_params,
         methods=methods,
-        threshold=threshold)
+        threshold=threshold) 
 
     with open(stats_report_filename, 'w') as fd:
         fd.write(str(level1_html_markup))
@@ -296,6 +295,7 @@ powered by <a href="%s">nipy</a>.""" % (user_script_name,
 
         for design_matrix, j in zip(design_matrices,
                                     range(len(design_matrices))):
+            """
             # sanitize design_matrix type
             if isinstance(design_matrix, basestring):
                 if not isinstance(design_matrix, DesignMatrix):
@@ -313,9 +313,20 @@ powered by <a href="%s">nipy</a>.""" % (user_script_name,
                 X = np.array(design_matrix)
                 conditions = ['%i' % i for i in range(X.shape[-1])]
                 design_matrix = DesignMatrix(X, conditions)
+            """
+            # XXX NISTATS
+            if isinstance(design_matrix, basestring):
+                if not isinstance(design_matrix, DataFrame):
+                    # XXX should be a DataFrame pickle here ?
+                    print design_matrix
+                    design_matrix = read_pickle(design_matrix)
+                else:
+                    raise TypeError(
+                        "Unsupported design matrix type: %s" % type(
+                            design_matrix))
 
             # plot design_matrix proper
-            ax = design_matrix.show(rescale=True)
+            ax = plot_design_matrix(design_matrix)
             ax.set_position([.05, .25, .9, .65])
             dmat_outfile = os.path.join(output_dir,
                                         'design_matrix_%i.png' % (j + 1))

--- a/pypreprocess/reporting/glm_reporter.py
+++ b/pypreprocess/reporting/glm_reporter.py
@@ -7,7 +7,7 @@ from nilearn.plotting import plot_stat_map
 from nilearn.image import reorder_img
 from pypreprocess.external.nistats.design_matrix import plot_design_matrix
 from pypreprocess.external.nistats.glm import FMRILinearModel
-from pandas import DataFrame, read_pickle
+import pandas as pd
 from nilearn.masking import intersect_masks
 import base_reporter
 from ..cluster_level_analysis import cluster_stats
@@ -325,10 +325,10 @@ powered by <a href="%s">nistats</a>.""" % (user_script_name,
             """
             # XXX NISTATS
             if isinstance(design_matrix, basestring):
-                if not isinstance(design_matrix, DataFrame):
+                if not isinstance(design_matrix, pd.DataFrame):
                     # XXX should be a DataFrame pickle here ?
                     print design_matrix
-                    design_matrix = read_pickle(design_matrix)
+                    design_matrix = pd.read_pickle(design_matrix)
                 else:
                     raise TypeError(
                         "Unsupported design matrix type: %s" % type(

--- a/pypreprocess/spm_loader/utils.py
+++ b/pypreprocess/spm_loader/utils.py
@@ -9,7 +9,7 @@ import multiprocessing
 import nibabel as nb
 import numpy as np
 
-from ..external.nistats.glm import FMRILinearModel
+from pypreprocess.external.nistats.glm import FMRILinearModel
 
 
 # pypreprocess imports

--- a/pypreprocess/spm_loader/utils.py
+++ b/pypreprocess/spm_loader/utils.py
@@ -9,7 +9,8 @@ import multiprocessing
 import nibabel as nb
 import numpy as np
 
-from nipy.modalities.fmri.glm import FMRILinearModel
+from ..external.nistats.glm import FMRILinearModel
+
 
 # pypreprocess imports
 PYPREPROCESS_DIR = os.path.dirname(
@@ -225,8 +226,8 @@ def execute_glm(doc, out_dir, contrast_definitions=None,
 
     # instantiate GLM
     fmri_glm = FMRILinearModel(params['data'],
-                          params['design_matrices'],
-                          doc['mask'])
+                               params['design_matrices'],
+                               mask=doc['mask'])
 
     # fit GLM
     fmri_glm.fit(do_scaling=True, model=glm_model)

--- a/scripts/hcp_preproc_and_analysis.py
+++ b/scripts/hcp_preproc_and_analysis.py
@@ -14,7 +14,7 @@ import numpy as np
 import nibabel
 import commands
 from nipy.modalities.fmri.glm import FMRILinearModel
-from nipy.labs.mask import intersect_masks
+from nilearn.masking import intersect_masks
 from pypreprocess.nipype_preproc_spm_utils import (SubjectData,
                                                    _do_subject_realign,
                                                    do_subject_preproc)

--- a/spike/glm_utils.py
+++ b/spike/glm_utils.py
@@ -254,7 +254,7 @@ if __name__ == "__maih__":
 
     # plot stats (per subject)
     import matplotlib.pyplot as plt
-    import nipy.labs.viz as viz
+    from nilearn.plotting import plot_stat_map
     all_masks = []
     all_effects_maps = []
     for (subject_id, anat, effects_maps, z_maps,
@@ -264,10 +264,6 @@ if __name__ == "__maih__":
         z_map = nibabel.load(z_maps.values()[0])
         all_effects_maps.append(effects_maps)
         for contrast_id, z_map in z_maps.iteritems():
-            z_map = nibabel.load(z_map)
-            viz.plot_map(z_map.get_data(), z_map.get_affine(),
-                         anat=anat_img.get_data(),
-                         anat_affine=anat_img.get_affine(), slicer='ortho',
-                         title="%s: %s" % (subject_id, contrast_id),
-                         black_bg=True, cmap=viz.cm.cold_hot, threshold=2.3)
+            plot_stat_map(z_map, black_bg=True, threshold=2.3,
+                          title="%s: %s" % (subject_id, contrast_id))
             plt.savefig("%s_%s.png" % (subject_id, contrast_id))

--- a/spike/sprint.py
+++ b/spike/sprint.py
@@ -234,7 +234,7 @@ if __name__ == "__main__":
 
     # plot stats (per subject)
     import matplotlib.pyplot as plt
-    import nipy.labs.viz as viz
+    from nilearn.plotting import plot_stat_map
     all_masks = []
     all_effects_maps = []
     for (subject_id, anat, effects_maps, z_maps,
@@ -244,10 +244,6 @@ if __name__ == "__main__":
         z_map = nibabel.load(z_maps.values()[0])
         all_effects_maps.append(effects_maps)
         for contrast_id, z_map in z_maps.iteritems():
-            z_map = nibabel.load(z_map)
-            viz.plot_map(z_map.get_data(), z_map.get_affine(),
-                         anat=anat_img.get_data(),
-                         anat_affine=anat_img.get_affine(), slicer='ortho',
-                         title="%s: %s" % (subject_id, contrast_id),
-                         black_bg=True, cmap=viz.cm.cold_hot, threshold=2.3)
+            plot_stat_map(z_map, black_bg=True, threshold=2.3,
+                          title="%s: %s" % (subject_id, contrast_id))
             plt.savefig("%s_%s.png" % (subject_id, contrast_id))


### PR DESCRIPTION
Addresses #172 
A first attempt to replace nipy by nistats.
The nipy dependency and sub dependencies are replaced by pandas only.
The glm functions keep the same structure, the nipy `DesignMatrix` is replaced by `DataFrame`.
The impact is on the reporter, the examples and the continuous integration.

CircleCI is running successfully 3 examples that are not too long.
https://circleci.com/gh/mrahim/pypreprocess/190

Travis is okay too.
https://travis-ci.org/mrahim/pypreprocess/builds/92285255