### PR TITLE
Better ini error message when ini file is not in the run folder

### DIFF
--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -1519,12 +1519,17 @@ def do_subjects_preproc(subject_factory, session_ids=None, **preproc_params):
     # load .ini ?
     preproc_details = None
     if isinstance(subject_factory, basestring):
-        with open(subject_factory, "r") as fd:
-            preproc_details = fd.read()
-            fd.close()
+        try:
+            with open(subject_factory, "r") as fd:
+                preproc_details = fd.read()
+                fd.close()
+        except IOError:
+            raise IOError('Could not load %s, please make sure to run your '
+                          'script within the same folder'
+                          ' as the .ini file' % subject_factory)
         subject_factory, _preproc_params = _generate_preproc_pipeline(
-            subject_factory, dataset_dir=preproc_params.get(
-                "dataset_dir", None))
+        subject_factory, dataset_dir=preproc_params.get(
+            "dataset_dir", None))
         _preproc_params.update(preproc_params)
         preproc_params = _preproc_params
 


### PR DESCRIPTION
All in the title.

The modified file is not tested (which is bad), but much bravoure would be needed to address this terrible lack.

running `python examples/easy_start/nipype_preproc_spm_auditory.py` from root now yields: 
```
Traceback (most recent call last):
  File "examples/easy_start/nipype_preproc_spm_auditory.py", line 49, in <module>
    subject_data = do_subjects_preproc(jobfile, dataset_dir=dataset_dir)[0]
  File "/home/arthur/.conda/envs/py27/lib/python2.7/site-packages/pypreprocess/nipype_preproc_spm_utils.py", line 1529, in do_subjects_preproc
    ' as the .ini file' % subject_factory)
IOError: Could not load spm_auditory_preproc.ini, please make sure to run your script within the same folder as the .ini file
```