### PR TITLE
Use a workaround to make reports work in Chrome browser.

### DIFF
--- a/examples/easy_start/nipype_preproc_spm_auditory.py
+++ b/examples/easy_start/nipype_preproc_spm_auditory.py
@@ -82,17 +82,17 @@ fmri_glm = FirstLevelGLM(noise_model='ar1', standardize=False).fit(
 
 # save computed mask
 mask_path = os.path.join(subject_data.output_dir, "mask.nii.gz")
-print "Saving mask image %s" % mask_path
+print("Saving mask image %s" % mask_path)
 nibabel.save(fmri_glm.masker_.mask_img_, mask_path)
 
 # compute bg unto which activation will be projected
 anat_img = nibabel.load(subject_data.anat)
 
-print "Computing contrasts .."
+print("Computing contrasts ..")
 z_maps = {}
 effects_maps = {}
 for contrast_id, contrast_val in contrasts.iteritems():
-    print "\tcontrast id: %s" % contrast_id
+    print("\tcontrast id: %s" % contrast_id)
     z_map, t_map, eff_map, var_map = fmri_glm.transform(
         contrasts[contrast_id], contrast_name=contrast_id, output_z=True,
         output_stat=True, output_effects=True, output_variance=True)
@@ -112,9 +112,9 @@ for contrast_id, contrast_val in contrasts.iteritems():
         if contrast_id == 'active-rest' and dtype == "z":
             z_maps[contrast_id] = map_path
 
-        print "\t\t%s map: %s" % (dtype, map_path)
+        print("\t\t%s map: %s" % (dtype, map_path))
 
-    print
+    print()
 
 # do stats report
 stats_report_filename = os.path.join(subject_data.reports_output_dir,
@@ -141,4 +141,4 @@ generate_subject_stats_report(
     drift_model=drift_model,
     hrf_model=hrf_model)
 
-print "\r\nStatistic report written to %s\r\n" % stats_report_filename
+print("\r\nStatistic report written to %s\r\n" % stats_report_filename)

--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -13,8 +13,8 @@ import warnings
 import inspect
 import numpy as np
 import nibabel
-from slice_timing import get_slice_indices
-from conf_parser import _generate_preproc_pipeline
+from .slice_timing import get_slice_indices
+from .conf_parser import _generate_preproc_pipeline
 import matplotlib
 matplotlib.use('Agg')
 from sklearn.externals.joblib import Parallel, delayed, Memory as JoblibMemory
@@ -24,7 +24,7 @@ from configure_spm import _configure_spm, _get_version_spm
 from .io_utils import (
     load_vols, ravel_filenames, unravel_filenames, get_vox_dims,
     niigz2nii, resample_img, compute_output_voxel_size, sanitize_fwhm)
-from subject_data import SubjectData
+from .subject_data import SubjectData
 from .reporting.base_reporter import (
     ResultsGallery, ProgressReport, copy_web_conf_files,
     get_module_source_code, dict_to_html_ul)
@@ -33,7 +33,7 @@ from .reporting.preproc_reporter import (
     get_dataset_report_log_html_template,
     get_dataset_report_preproc_html_template,
     get_dataset_report_html_template)
-from purepython_preproc_utils import (
+from .purepython_preproc_utils import (
     _do_subject_slice_timing as _pp_do_subject_slice_timing,
     _do_subject_realign as _pp_do_subject_realign,
     _do_subject_coregister as _pp_do_subject_coregister,

--- a/pypreprocess/reporting/base_reporter.py
+++ b/pypreprocess/reporting/base_reporter.py
@@ -250,6 +250,7 @@ class ResultsGallery(object):
                  title='Results', description=None):
         self.loader_filename = loader_filename
         self.refresh_timeout = refresh_timeout
+        self._page_id = os.path.basename(loader_filename).split('.')[0]
         self.title = title
         self.description = description
 
@@ -280,7 +281,13 @@ class ResultsGallery(object):
         self.raw = get_gallery_html_markup().substitute(thumbnails=thumbnails)
 
         fd = open(self.loader_filename, 'a')
-        fd.write(self.raw)
+        # This is a small hack to allow file inclusion in Chrome
+        fd.write("var %s = '\\\n" % self._page_id)
+        html_code = self.raw
+        html_code = html_code.replace("'", "\\'")
+        html_code = html_code.replace("\n", "\\\n")
+        fd.write(html_code)
+        fd.write("';")
         fd.close()
 
 

--- a/pypreprocess/reporting/template_reports/subject_report_stats_template.tmpl.html
+++ b/pypreprocess/reporting/template_reports/subject_report_stats_template.tmpl.html
@@ -54,8 +54,7 @@
     <br clear="all"/>   
     <hr/>
 
-    <script type="text/javascript">
-      $('#design').load("{{design_thumbs}}").fadeIn("slow");
+    <script type="text/javascript" src='design.html'>
     </script>
     <b>Experimental design</b><br/><br/>
     {{if not design_params is None}}
@@ -66,8 +65,7 @@
     <br clear="all"/>
     <hr/>
     
-    <script type="text/javascript">
-      $('#activation').load("{{activation_thumbs}}").fadeIn("slow");
+    <script type="text/javascript" src='activation.html'>
     </script>
     <b>Thresholded activation maps{{if not threshold is None}} (threshold = {{threshold}}){{endif}}</b><br/><br/>
     Below are thresholded activation z-maps{{if not cmap is None}} (<b>cmap = "{{cmap}}"</b>){{endif}} for the different contrasts of interest. Click on a thumbnail for more details.<br/>
@@ -107,8 +105,8 @@
       });
 
       $(document).ready(function(){
-      $('#design').load("{{design_thumbs}}").fadeIn("slow");
-      $('#activation').load("{{activation_thumbs}}").fadeIn("slow");    
+      $('#design').html(design).fadeIn("slow");
+      $('#activation').html(activation).fadeIn("slow");    
       });
     </script>
 


### PR DESCRIPTION
Fix #31 

In order to load HTML code without using an iFrame, I load the html code in a javascript variable and use it in jQuery afterward. I kept the "html" extension of the files on purpose just to know that it is not proper JS code.
