### PR TITLE
Mem issue plot register

### DIFF
--- a/pypreprocess/reporting/check_preprocessing.py
+++ b/pypreprocess/reporting/check_preprocessing.py
@@ -91,8 +91,8 @@ def plot_registration(reference_img, coregistered_img,
     if cmap is None:
         cmap = plt.cm.gray  # registration QA always gray cmap!
 
-    reference_img = load_vols(reference_img)[0]
-    coregistered_img = load_vols(coregistered_img)[0]
+    reference_img = mean_img(reference_img)
+    coregistered_img = mean_img(coregistered_img)
 
     if cut_coords is None:
         cut_coords = (-10, -28, 17)
@@ -108,9 +108,8 @@ def plot_registration(reference_img, coregistered_img,
 
     # XXX nilearn complains about rotations in affine, etc.
     reference_img = reorder_img(reference_img, resample="continuous")
-
+    
     _slicer.add_edges(reference_img)
-
     # misc
     _slicer.title(title, size=12, color='w', alpha=0)
 


### PR DESCRIPTION
Plot register currently concatenates volumes and then extract the first one for plotting. This is super-inefficient and lead to dramatic errors with current biggish fMRI files (e.g. 2GB per 4D image * 6 images). Extract the mean instead.