### PR TITLE
[MRG] Fix test errors with numpy 1.12

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
     # Installing Pypreprocess dependencies
     - pip install --upgrade pip
     - |
-      pip install numpy==1.11 scipy sklearn nibabel configobj nose coverage\
+      pip install numpy scipy sklearn nibabel configobj nose coverage\
           matplotlib pandas nipype nilearn configparser
 
   override:

--- a/pypreprocess/kernel_smooth.py
+++ b/pypreprocess/kernel_smooth.py
@@ -200,8 +200,10 @@ class LinearFilter(object):
         self._norm = _get_kernel_norm(kernel, self._normalization)
 
         self._kernel = kernel
-        self._shape = (np.ceil((np.asarray(self._bshape) +
-                              np.asarray(kernel.shape)) / 2) * 2 + 2)
+        shape_array = (np.ceil((np.asarray(self._bshape) +
+                                np.asarray(kernel.shape)) / 2) * 2 + 2)
+        # shape needs to be a list of ints
+        self._shape = shape_array.astype('uint64').tolist()
         self.fkernel = np.zeros(self._shape)
         slices = [slice(0, kernel.shape[i]) for i in range(kernel.ndim)]
         self.fkernel[slices] = kernel

--- a/pypreprocess/tests/test_reslice.py
+++ b/pypreprocess/tests/test_reslice.py
@@ -11,8 +11,8 @@ def test_reslice_vols():
     # create basic L pattern
     n_scans = 3
     film = np.zeros((10, 10, 10, n_scans))
-    film[-3:, 5:-1, ..., ...] = 1
-    film[..., 2:5, ..., ...] = 1
+    film[-3:, 5:-1, :, :] = 1
+    film[:, 2:5, :, :] = 1
     affine = np.array(
         [[-2.99256921e+00, -1.12436414e-01, -2.23214120e-01,
           1.01544670e+02],

--- a/pypreprocess/tests/test_slice_timing.py
+++ b/pypreprocess/tests/test_slice_timing.py
@@ -70,8 +70,8 @@ def check_STC(true_signal, corrected_signal, ref_slice=0,
               rtol=None, atol=None):
     n_slices = true_signal.shape[2]
     np.testing.assert_array_almost_equal(
-        corrected_signal[..., ref_slice, ...],
-        true_signal[..., ref_slice, ...])
+        corrected_signal[..., ref_slice, :],
+        true_signal[..., ref_slice, :])
     for _ in range(1, n_slices):
         # relative closeness
         if rtol is not None:
@@ -187,7 +187,7 @@ def test_STC_for_HRF():
     # sample the time and the signal
     freq = 100
     TR = 3.
-    acquisition_time = time[::TR * freq]
+    acquisition_time = time[::int(TR * freq)]
     n_scans = len(acquisition_time)
 
     # corrupt the sampled time by shifting it to the right

--- a/pypreprocess/tests/test_tsdiffana.py
+++ b/pypreprocess/tests/test_tsdiffana.py
@@ -14,8 +14,8 @@ from nose.tools import assert_true, assert_false
 def make_test_data(n_scans=3):
     shape = (7, 8, 9, n_scans)
     film = np.zeros(shape)
-    film[-3:, 5:-1, ..., ...] = 1
-    film[..., 2:5, ..., ...] = 1
+    film[-3:, 5:-1, :, :] = 1
+    film[:, 2:5, :, :] = 1
     scal = np.sum(film) * 1. / film.size
     affine = np.eye(4)
     return nibabel.Nifti1Image(film, affine), scal
@@ -48,8 +48,8 @@ def test_ts_diff_ana():
     n_scans = 2
     shape = (7, 8, 9, n_scans)
     film = np.zeros(shape)
-    film[-3:, 5:-1, ..., ...] = 1
-    film[..., 2:5, ..., ...] = 1
+    film[-3:, 5:-1, :, :] = 1
+    film[:, 2:5, :, :] = 1
     ref = film.copy()
     scal = np.sum(ref) * 1. / ref.size
     film = np.dot(film, np.diag(np.arange(n_scans)))


### PR DESCRIPTION
* Multiple ellipsis are not allowed
* Slice arguments in indexing need to be a list (and not an array) of ints