### PR TITLE
remove hard coded paths from realign and slice timing examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@
 *.o
 *.so
 *.a
-
+*.swp
+*.log
+*.m
+build/
+examples/pure_python/demos_cache/
 .idea/
 .idea/workspace.xml
 .coverage

--- a/examples/pure_python/realign_demos.py
+++ b/examples/pure_python/realign_demos.py
@@ -4,6 +4,8 @@ Synopsis: single_subject_pipeline.py demo
 """
 
 import os
+import sys
+from tempfile import mkdtemp
 from collections import namedtuple
 import matplotlib.pyplot as plt
 from sklearn.externals.joblib import Memory
@@ -64,20 +66,17 @@ def _demo_runner(subjects, dataset_id, **spm_realign_kwargs):
                     subject_data.subject_id, sess, dataset_id))
 
 
-def demo_nyu_rest(output_dir="/tmp/nyu_mrimc_output",
-                  ):
+def demo_nyu_rest(output_dir):
     """Demo for FSL Feeds data.
 
     Parameters
     ----------
-    data_dir: string, optional
-        where the data is located on your disk, where it will be
-        downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
 
+    output_dir = os.path.join(output_dir, 'nyu_mrimc_output')
     # fetch data
     nyu_data = fetch_nyu_rest()
 
@@ -101,18 +100,16 @@ def demo_nyu_rest(output_dir="/tmp/nyu_mrimc_output",
     _demo_runner(subjects, "NYU resting state")
 
 
-def demo_fsl_feeds(output_dir="/tmp/fsl_feeds_mrimc_output"):
+def demo_fsl_feeds(output_dir):
     """Demo for FSL Feeds data.
 
     Parameters
     ----------
-    data_dir: string, optional
-        where the data is located on your disk, where it will be
-        downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
+    output_dir = os.path.join(output_dir, "fsl_feeds_mrimc_output")
     fsl_feeds = fetch_fsl_feeds()
     subject_id = "sub001"
     subjects = [SubjectData(subject_id=subject_id,
@@ -121,18 +118,16 @@ def demo_fsl_feeds(output_dir="/tmp/fsl_feeds_mrimc_output"):
     _demo_runner(subjects, "FSL FEEDS")
 
 
-def demo_spm_multimodal_fmri(output_dir="/tmp/spm_multimodal_fmri_output"):
+def demo_spm_multimodal_fmri(output_dir):
     """Demo for SPM multimodal fmri (faces vs scrambled)
 
     Parameters
     ----------
-    data_dir: string, optional
-        where the data is located on your disk, where it will be
-        downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
+    output_dir = os.path.join(output_dir, "spm_multimodal_fmri_output")
     spm_multimodal_fmri = fetch_spm_multimodal_fmri()
     subject_id = "sub001"
     subjects = [SubjectData(subject_id=subject_id,
@@ -143,18 +138,16 @@ def demo_spm_multimodal_fmri(output_dir="/tmp/spm_multimodal_fmri_output"):
                  n_sessions=2)
 
 
-def demo_spm_auditory(output_dir="/tmp/spm_auditory_output"):
+def demo_spm_auditory(output_dir):
     """Demo for SPM single-subject Auditory
 
     Parameters
     ----------
-    data_dir: string, optional
-        where the data is located on your disk, where it will be
-        downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
+    output_dir = os.path.join(output_dir, "spm_auditory_output")
     spm_auditory = fetch_spm_auditory()
     subject_id = "sub001"
     subjects = [SubjectData(subject_id=subject_id,
@@ -163,16 +156,25 @@ def demo_spm_auditory(output_dir="/tmp/spm_auditory_output"):
     _demo_runner(subjects, "SPM single-subject Auditory")
 
 if __name__ == '__main__':
+
+    output_root_dir = None
+    if (len(sys.argv) > 1):
+        output_root_dir = os.path.abspath(os.path.expanduser(sys.argv[1]))
+
+    if (output_root_dir is None or not os.path.isdir(output_root_dir)):
+        output_root_dir = mkdtemp()
+
     # run spm multimodal demo
-    demo_spm_auditory()
+    demo_spm_auditory(output_root_dir)
 
     # # run spm multimodal demo
-    # demo_spm_multimodal_fmri()
+    # demo_spm_multimodal_fmri(output_root_dir)
 
     # # run fsl feeds demo
-    # demo_fsl_feeds()
+    # demo_fsl_feeds(output_root_dir)
 
     # # run nyu_rest demo
-    # demo_nyu_rest()
+    # demo_nyu_rest(output_root_dir)
+    print("output written in {0}".format(output_root_dir))
 
     plt.show()

--- a/examples/pure_python/slice_timing_demos.py
+++ b/examples/pure_python/slice_timing_demos.py
@@ -7,6 +7,7 @@ import sys
 import os
 import warnings
 from collections import namedtuple
+from tempfile import mkdtemp
 import numpy as np
 import matplotlib.pyplot as plt
 import nibabel
@@ -20,7 +21,8 @@ from pypreprocess.reporting.preproc_reporter import generate_stc_thumbnails
 SubjectData = namedtuple('SubjectData', 'subject_id func output_dir')
 
 
-def demo_random_brain(n_rows=62, n_columns=40, n_slices=10, n_scans=240):
+def demo_random_brain(output_dir, n_rows=62, n_columns=40, n_slices=10,
+                      n_scans=240):
     """Now, how about STC for brain packed with white-noise ? ;)
 
     """
@@ -41,10 +43,10 @@ def demo_random_brain(n_rows=62, n_columns=40, n_slices=10, n_scans=240):
 
     # QA clinic
     generate_stc_thumbnails([brain_data], [stc.get_last_output_data()],
-                            '/tmp/', close=False)
+                            output_dir, close=False)
 
 
-def demo_sinusoidal_mixture(n_slices=10, n_rows=3, n_columns=2,
+def demo_sinusoidal_mixture(output_dir, n_slices=10, n_rows=3, n_columns=2,
                           introduce_artefact_in_these_volumes=None,
                           artefact_std=4.,
                           white_noise_std=1e-2):
@@ -141,10 +143,10 @@ def demo_sinusoidal_mixture(n_slices=10, n_rows=3, n_columns=2,
 
     # QA clinic
     generate_stc_thumbnails(acquired_signal,
-                            st_corrected_signal, '/tmp/', close=False)
+                            st_corrected_signal, output_dir, close=False)
 
 
-def demo_HRF(n_slices=10,
+def demo_HRF(output_dir, n_slices=10,
              n_rows=2,
              n_columns=3,
              white_noise_std=1e-4,
@@ -231,11 +233,12 @@ def demo_HRF(n_slices=10,
 
     # QA clinic
     generate_stc_thumbnails(acquired_sample,
-                            stc.get_last_output_data(), '/tmp/',
+                            stc.get_last_output_data(), output_dir,
                             close=False)
 
 
-def _fmri_demo_runner(subjects, dataset_id, **spm_slice_timing_kwargs):
+def _fmri_demo_runner(output_dir, subjects, dataset_id,
+                      **spm_slice_timing_kwargs):
     """Demo runner.
 
     Parameters
@@ -299,13 +302,14 @@ def _fmri_demo_runner(subjects, dataset_id, **spm_slice_timing_kwargs):
         # plot results
         generate_stc_thumbnails([stc.get_raw_data()],
                                 [stc.get_last_output_data()],
-                                '/tmp', close=False)
+                                output_dir, close=False)
 
 
-def demo_localizer(output_dir="/tmp/localizer_output"):
+def demo_localizer(output_dir):
+    output_dir = os.path.join(output_dir, "localizer_output")
     data_path = os.path.join(
         os.environ["HOME"],
-        ".nipy/tests/data/s12069_swaloc1_corr.nii.gz")
+        ".nipy", "tests", "data", "s12069_swaloc1_corr.nii.gz")
     if not os.path.exists(data_path):
         warnings.warn("You don't have nipy test data installed!")
         return
@@ -314,22 +318,19 @@ def demo_localizer(output_dir="/tmp/localizer_output"):
     subject_data = SubjectData(subject_id=subject_id, func=data_path,
                                output_dir=os.path.join(output_dir, subject_id))
 
-    _fmri_demo_runner([subject_data], "localizer")
+    _fmri_demo_runner(output_dir, [subject_data], "localizer")
 
 
-def demo_spm_multimodal_fmri(output_dir="/tmp/spm_multimodal_fmri_output"):
+def demo_spm_multimodal_fmri(output_dir):
     """Demo for SPM multimodal fmri (faces vs scrambled)
 
     Parameters
     ----------
-    data_dir: string, optional
-        where the data is located on your disk, where it will be
-        downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
-
+    output_dir = os.path.join(output_dir, "spm_multimodal_fmri_output")
     # fetch data
     spm_multimodal_fmri = fetch_spm_multimodal_fmri()
 
@@ -341,12 +342,11 @@ def demo_spm_multimodal_fmri(output_dir="/tmp/spm_multimodal_fmri_output"):
                           output_dir=os.path.join(output_dir, subject_id))
 
     # invoke demon to run de demo
-    _fmri_demo_runner(subject_factory(),
+    _fmri_demo_runner(output_dir, subject_factory(),
                       "SPM Multimodal fMRI faces vs scrambled session 1")
 
 
-def demo_nyu_rest(data_dir="/tmp/nyu_data", n_subjects=1,
-                  output_dir="/tmp/nyu_rest_output"):
+def demo_nyu_rest(output_dir, n_subjects=1):
     """Demo for FSL Feeds data.
 
     Parameters
@@ -354,13 +354,13 @@ def demo_nyu_rest(data_dir="/tmp/nyu_data", n_subjects=1,
     data_dir: string, optional
         where the data is located on your disk, where it will be
         downloaded to
-    output_dir: string, optional
+    output_dir: string
         where output will be written to
 
     """
-
+    output_dir = os.path.join(output_dir, "nyu_rest_output")
     # fetch data
-    nyu_data = fetch_nyu_rest(data_dir=data_dir, n_subjects=n_subjects)
+    nyu_data = fetch_nyu_rest(n_subjects=n_subjects)
 
     # subject data factory
     def subject_factory(session=1):
@@ -379,20 +379,29 @@ def demo_nyu_rest(data_dir="/tmp/nyu_data", n_subjects=1,
                                   subject_id))
 
     # invoke demon to run de demo
-    _fmri_demo_runner(subject_factory(), "NYU Resting State")
+    _fmri_demo_runner(output_dir, subject_factory(), "NYU Resting State")
 
 
 if __name__ == '__main__':
     this_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     jobfile = os.path.join(this_dir, "multimodal_faces_preproc.ini")
 
+    output_root_dir = None
+    if (len(sys.argv) > 1):
+        output_root_dir = os.path.abspath(os.path.expanduser(sys.argv[1]))
+
+    if (output_root_dir is None or not os.path.isdir(output_root_dir)):
+        output_root_dir = mkdtemp()
+
     # demo on simulated data
-    demo_random_brain()
-    demo_sinusoidal_mixture()
-    demo_HRF()
+    demo_random_brain(output_root_dir)
+    demo_sinusoidal_mixture(output_root_dir)
+    demo_HRF(output_root_dir)
 
     # demo on real data
-    demo_localizer()
-    demo_spm_multimodal_fmri()
+    demo_localizer(output_root_dir)
+    demo_spm_multimodal_fmri(output_root_dir)
+
+    print("output written in {0}".format(output_root_dir))
 
     plt.show()


### PR DESCRIPTION
about issue #157 
pure_python_preproc_demo.py doesn't work for me, I thought we should fix that before changing the paths.
In coreg_demo.py, I don't know what the paths in @dohmatob 's filesystem correspond to, if I download ABIDE using the nilearn fetcher the paths are different. Elvis, could we obtain the same files with the nilearn downloader?