### PR TITLE
MRG : coreg for MGH images + cosmits

### DIFF
--- a/pypreprocess/coreg.py
+++ b/pypreprocess/coreg.py
@@ -358,7 +358,7 @@ class Coregister(object):
         self.params_ = np.array(self.params_init)
         for samp in self.sep:
             print("\r\nRunning Powell gradient-less local optimization "
-                  "(pyramidal level = %smm)...") % samp
+                  "(pyramidal level = %smm)..." % samp)
 
             # create sampled grid for target img
             grid = make_sampled_grid(target.shape, samp=_correct_voxel_samp(
@@ -406,7 +406,7 @@ class Coregister(object):
             the coregistered source volume
         """
         # save output unto disk
-        if not output_dir is None:
+        if output_dir is not None:
             if basenames is None:
                 basenames = get_basenames(source)
 
@@ -414,7 +414,7 @@ class Coregister(object):
         # XXX backend should handle nasty i/o logic!!
         coregistered_source = list(apply_realignment(source, self.params_,
                                                      inverse=True))
-        if not output_dir is None:
+        if output_dir is not None:
             concat = isinstance(basenames, _basestring)
             coregistered_source = save_vols(coregistered_source,
                                             output_dir=output_dir,

--- a/pypreprocess/io_utils.py
+++ b/pypreprocess/io_utils.py
@@ -31,7 +31,8 @@ def is_niimg(img):
     if isinstance(img, (nibabel.Nifti1Image,
                         nibabel.Nifti1Pair,
                         nibabel.Spm2AnalyzeImage,
-                        nibabel.Spm99AnalyzeImage
+                        nibabel.Spm99AnalyzeImage,
+                        nibabel.MGHImage,
                         # add other supported image types below (e.g
                         # AnalyseImage, etc.)
                         )):


### PR DESCRIPTION
closes #279

but my attempt is not very  successful:

![screen shot 2017-05-08 at 18 21 21](https://cloud.githubusercontent.com/assets/161052/25813859/6c3300b4-341b-11e7-8bb9-f38c6c583da9.png)

obtained with:

```
from pypreprocess.coreg import Coregister
import nibabel as nib

source = '/Users/alex/mne_data/MNE-sample-data/subjects/sample/mri/T1.mgz'
target = '/Users/alex/mne_data/MNE-sample-data/subjects/fsaverage/mri/T1.mgz'

coreg = Coregister()
coreg.fit(source, target)
source_coreg = coreg.transform(source)
source_coreg = source_coreg[0]
nib.save(source_coreg, 'T1_sample2fsaverage.nii')
```

