### PR TITLE
Fix: Failing due to deprecated colormap spectral

### DIFF
--- a/pypreprocess/reporting/preproc_reporter.py
+++ b/pypreprocess/reporting/preproc_reporter.py
@@ -1069,7 +1069,7 @@ def generate_subject_preproc_report(
             subject_gm_file=gm,
             subject_wm_file=wm,
             subject_csf_file=csf,
-            cmap=pl.cm.spectral,
+            cmap=pl.cm.nipy_spectral,
             brain="EPI",
             results_gallery=results_gallery,
             )

--- a/pypreprocess/subject_data.py
+++ b/pypreprocess/subject_data.py
@@ -762,7 +762,7 @@ class SubjectData(object):
         # generate thumbnails proper
         for brain_name, brain, cmap in zip(
                 ['anatomical_image', 'mean_functional_image'],
-                [self.anat, self.func], [cm.gray, cm.spectral]):
+                [self.anat, self.func], [cm.gray, cm.nipy_spectral]):
             if not brain:
                 continue
             thumbs = generate_segmentation_thumbnails(
@@ -794,7 +794,7 @@ class SubjectData(object):
         # generate thumbnails proper
         for brain_name, brain, cmap in zip(
                 ['anatomical_image', 'mean_functional_image'],
-                [self.anat, self.func], [cm.gray, cm.spectral]):
+                [self.anat, self.func], [cm.gray, cm.nipy_spectral]):
             if not brain:
                 continue
 


### PR DESCRIPTION
The newest release of matplotlib v2.2 removed the colormap spectral. This can be replaced by nipy_spectral. Otherwise, we have failures with processing output files.

Can I have reviews and merge ?

Thanks