### PR TITLE
Remove .hold attribute to comply with new API Matplotlib 3.0.0

### DIFF
--- a/pypreprocess/reporting/preproc_reporter.py
+++ b/pypreprocess/reporting/preproc_reporter.py
@@ -869,7 +869,6 @@ def generate_stc_thumbnails(original_bold, st_corrected_bold, output_dir,
                                        'stc_plot_%s.png' % session_id)
         pl.figure()
         pl.plot(o_ts, 'o-')
-        pl.hold('on')
         pl.plot(stc_ts, 's-')
         pl.legend(('original BOLD', 'ST corrected BOLD'))
         pl.title("session %s: STC QA for voxel (%s, %s, %s)" % (

--- a/pypreprocess/time_diff.py
+++ b/pypreprocess/time_diff.py
@@ -230,11 +230,9 @@ def plot_tsdiffs(results, use_same_figure=True):
 
     # slice plots min max mean
     ax = next(iter_axes)
-    ax.hold(True)
     ax.plot(np.mean(scaled_slice_diff, 0), 'k')
     ax.plot(np.min(scaled_slice_diff, 0), 'b')
     ax.plot(np.max(scaled_slice_diff, 0), 'r')
-    ax.hold(False)
     xmax_labels(ax, S + 1, 'Slice number',
                 'Max/mean/min \n slice variation')
 


### PR DESCRIPTION
Running pypreprocess with default settings from my computer will now return the error: 
`AttributeError: 'AxesSubplot' object has no attribute 'add_axes'`

This is due to the removal of `hold` attribute in Matplotlib 3.0.0. Matplotlib now always behaves as if hold=True. Details: https://matplotlib.org/api/api_changes.html#removals
