### PR TITLE
Set smoothing in realignment as variable

### DIFF
--- a/pypreprocess/realign.py
+++ b/pypreprocess/realign.py
@@ -24,7 +24,7 @@ INFINITY = np.inf
 
 
 def _single_volume_fit(moving_vol, fixed_vol_affine, fixed_vol_A0, affine_correction, b, x1, x2,
-                       x3, fwhm, n_iterations, interp, lkp, tol,
+                       x3, fwhm, n_iterations, interp, lkp, tol, smooth_func=smooth_image,
                        log=lambda x: None):
     """
     Realigns moving_vol to fixed_vol.
@@ -96,7 +96,7 @@ def _single_volume_fit(moving_vol, fixed_vol_affine, fixed_vol_A0, affine_correc
     # initialize final rp for this vol
     vol_rp = get_initial_motion_params()
     # smooth volume t
-    V = smooth_image(moving_vol, fwhm).get_data()
+    V = smooth_func(moving_vol, fwhm).get_data()
     # global optical flow problem with affine motion model: run
     # Gauss-Newton iterated LS (this loop should normally converge
     # after about as few as 5 iterations)
@@ -304,7 +304,8 @@ class MRIMotionCorrection(object):
     """
 
     def __init__(self, sep=4, interp=3, fwhm=5., quality=.9, tol=1e-8,
-                 lkp=None, verbose=1, n_iterations=64, n_sessions=1):
+                 lkp=None, verbose=1, n_iterations=64, n_sessions=1,
+                 smooth_func=smooth_image):
         lkp = [0, 1, 2, 3, 4, 5] if lkp is None else lkp
         self.sep = sep
         self.interp = interp
@@ -315,6 +316,7 @@ class MRIMotionCorrection(object):
         self.verbose = verbose
         self.n_iterations = n_iterations
         self.n_sessions = n_sessions
+        self.smooth_func = smooth_func
 
     def _log(self, msg):
         """Logs a message, according to verbose level.
@@ -387,7 +389,7 @@ class MRIMotionCorrection(object):
                               0:dim[2] - .5 - 1:skip[2]].reshape((3, -1))
 
         # smooth 0th volume to absorb noise before differentiating
-        sref_vol = smooth_image(vol_0, self.fwhm).get_data()
+        sref_vol = self.smooth_func(vol_0, self.fwhm).get_data()
 
         # resample the smoothed reference volume unto doped working grid
         G = ndimage.map_coordinates(sref_vol, [x1, x2, x3], order=self.interp,
@@ -473,7 +475,8 @@ class MRIMotionCorrection(object):
                                   b, x1, x2, x3, fwhm=self.fwhm,
                                   n_iterations=self.n_iterations,
                                   interp=self.interp, lkp=self.lkp,
-                                  tol=self.tol, **svf_kwargs) for vol in vols[1:])
+                                  tol=self.tol, smooth_func=self.smooth_func,
+                                  **svf_kwargs) for vol in vols[1:])
         rp[1:, ...] = np.array(rps)
 
         return rp

--- a/pypreprocess/realign.py
+++ b/pypreprocess/realign.py
@@ -80,6 +80,10 @@ def _single_volume_fit(moving_vol, fixed_vol_affine, fixed_vol_A0, affine_correc
         
     tol: float
         tolerance for Gauss-Newton LS iterations
+
+    smooth_func: function, optional (default pypreprocess' smooth_image)
+        the smoothing function to apply during estimation. The given function
+        must accept 2 positional args (vol, fwhm)
         
     log: function, optional (default lambda x: None)
         function used for storing log messages
@@ -291,6 +295,10 @@ class MRIMotionCorrection(object):
     n_iterations: int, optional (dafault 64)
         max number of Gauss-Newton iterations when solving LSP for
         registering a volume to the reference
+
+    smooth_func: function, optional (default pypreprocess' smooth_image)
+        the smoothing function to apply during estimation. The given function
+        must accept 2 positional args (vol, fwhm)
 
     Attributes
     ----------

--- a/pypreprocess/tests/test_realign.py
+++ b/pypreprocess/tests/test_realign.py
@@ -182,98 +182,44 @@ def test_MRIMotionCorrection_fit():
 
     film = apply_realignment(film, rp)
 
+    _kwargs = {'quality': 1., 'lkp': lkp}
     for n_jobs in [1, 2]:
-        # instantiate object
-        mrimc = MRIMotionCorrection(quality=1., lkp=lkp).fit([film],
-                                                             n_jobs=n_jobs)
+        for smooth_func in [None, nibabel_smoothing]:
+            kwargs = _kwargs.copy()
+            if smooth_func is not None:
+                kwargs['smooth_func'] = smooth_func
+            # instantiate object
+            mrimc = MRIMotionCorrection(**kwargs).fit([film], n_jobs=n_jobs)
 
-        # check shape of realignment params
-        np.testing.assert_array_equal(np.array(
-            mrimc.realignment_parameters_).shape, [1] + [n_scans, 6])
+            # check shape of realignment params
+            np.testing.assert_array_equal(np.array(
+                mrimc.realignment_parameters_).shape, [1] + [n_scans, 6])
 
-        # check that we estimated the correct motion params
-        # XXX refine the notion of "closeness" below
-        for t in range(n_scans):
-            _tmp = get_initial_motion_params()[:6]
+            # check that we estimated the correct motion params
+            # XXX refine the notion of "closeness" below
+            for t in range(n_scans):
+                _tmp = get_initial_motion_params()[:6]
 
-            # check the estimated motion is well within our MAX_RE limit
-            _tmp[:3] += _make_vol_specific_translation(translation, n_scans, t)
-            _tmp[3:6] += _make_vol_specific_rotation(rotation, n_scans, t)
-            if t > 0: np.testing.assert_allclose(
-                    mrimc.realignment_parameters_[0][t][lkp],
-                    _tmp[lkp], rtol=MAX_RE)
-            else: np.testing.assert_array_equal(
-                    mrimc.realignment_parameters_[0][t],
-                    get_initial_motion_params()[:6])
+                # check the estimated motion is well within our MAX_RE limit
+                _tmp[:3] += _make_vol_specific_translation(
+                    translation, n_scans, t)
+                _tmp[3:6] += _make_vol_specific_rotation(rotation, n_scans, t)
+                if t > 0: np.testing.assert_allclose(
+                        mrimc.realignment_parameters_[0][t][lkp],
+                        _tmp[lkp], rtol=MAX_RE)
+                else: np.testing.assert_array_equal(
+                        mrimc.realignment_parameters_[0][t],
+                        get_initial_motion_params()[:6])
 
-        ####################
-        # check transform
-        ####################
-        mrimc_output = mrimc.transform(output_dir)
-        assert_equal(len(mrimc_output['realigned_images']), 1)
-        assert_equal(len(set(mrimc_output['realigned_images'][0])), n_scans)
-        assert_equal(len(set(mrimc_output['realigned_images'][0])), n_scans)
-
-
-def test_MRIMotionCorrection_fit_with_nibabel_smoothing():
-    # setup
-    output_dir = os.path.join(OUTPUT_DIR, inspect.stack()[0][3])
-    if not os.path.exists(output_dir): os.makedirs(output_dir)
-    n_scans = 2
-    lkp = np.arange(6)
-    translation = np.array([1, 3, 2])  # mm
-    rotation = np.array([1, 2, .5])  # degrees
-    MAX_RE = .12  # we'll test for this max relative error in estimating motion
-
-    # create data
-    vol = scipy.io.loadmat(os.path.join(THIS_DIR,
-                                        "test_data/spmmmfmri.mat"),
-                           squeeze_me=True, struct_as_record=False)
-    data = np.ndarray(list(vol['data'].shape) + [n_scans])
-    for t in range(n_scans): data[..., t] = vol['data']
-    film = nibabel.Nifti1Image(data, vol['affine'])
-
-    # rigidly move other volumes w.r.t. the first
-    rp = np.array([get_initial_motion_params() for _ in range(n_scans)])
-    for t in range(n_scans):
-        rp[t, ...][:3] += _make_vol_specific_translation(
-            translation, n_scans, t)
-        rp[t, ...][3:6] += _make_vol_specific_rotation(rotation, n_scans, t)
-
-    film = apply_realignment(film, rp)
-
-    for n_jobs in [1, 2]:
-        # instantiate object
-        mrimc = MRIMotionCorrection(
-            quality=1., lkp=lkp, smooth_func=nibabel_smoothing).fit([film],
-                                                                    n_jobs=n_jobs)
-
-        # check shape of realignment params
-        np.testing.assert_array_equal(np.array(
-            mrimc.realignment_parameters_).shape, [1] + [n_scans, 6])
-
-        # check that we estimated the correct motion params
-        # XXX refine the notion of "closeness" below
-        for t in range(n_scans):
-            _tmp = get_initial_motion_params()[:6]
-
-            # check the estimated motion is well within our MAX_RE limit
-            _tmp[:3] += _make_vol_specific_translation(translation, n_scans, t)
-            _tmp[3:6] += _make_vol_specific_rotation(rotation, n_scans, t)
-            if t > 0: np.testing.assert_allclose(
-                    mrimc.realignment_parameters_[0][t][lkp],
-                    _tmp[lkp], rtol=MAX_RE)
-            else: np.testing.assert_array_equal(
-                    mrimc.realignment_parameters_[0][t],
-                    get_initial_motion_params()[:6])
-
-        ####################
-        # check transform
-        ####################
-        mrimc_output = mrimc.transform(output_dir)
-        assert_equal(len(mrimc_output['realigned_images']), 1)
-        assert_equal(len(set(mrimc_output['realigned_images'][0])), n_scans)
-        assert_equal(len(set(mrimc_output['realigned_images'][0])), n_scans)
+            ####################
+            # check transform
+            ####################
+            mrimc_output = mrimc.transform(output_dir)
+            assert_equal(len(mrimc_output['realigned_images']), 1)
+            assert_equal(len(set(mrimc_output['realigned_images'][0])),
+                         n_scans)
+            assert_equal(len(set(mrimc_output['realigned_images'][0])),
+                         n_scans)
 
 
 @nottest


### PR DESCRIPTION
Hi,
I wanted the option to use a different smoothing function during realignment, so i added an argument in the corresponding class (and function) that represents the desired smoothing function to apply. I think this can be useful to others too, hence the PR.

The default value is set to pypreprocess' smoothing, so the current functionality doesn't change.

As an example, in order to use nibabel's smoothing:
```
from nibabel.processing import smooth_image

mrimc = MRIMotionCorrection(smooth_func=smooth_image)
```