### PR TITLE
[MRG] Added LooseVersion matplotlib check for attributes deprecated after 2.0

### DIFF
--- a/pypreprocess/reporting/preproc_reporter.py
+++ b/pypreprocess/reporting/preproc_reporter.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import time
 import json
+import matplotlib
 import numpy as np
 import pylab as pl
 import nibabel

--- a/pypreprocess/reporting/preproc_reporter.py
+++ b/pypreprocess/reporting/preproc_reporter.py
@@ -15,6 +15,7 @@ import json
 import numpy as np
 import pylab as pl
 import nibabel
+from distutils.version import LooseVersion
 from nilearn._utils.compat import _basestring
 from sklearn.externals import joblib
 from .check_preprocessing import (plot_registration,
@@ -869,7 +870,8 @@ def generate_stc_thumbnails(original_bold, st_corrected_bold, output_dir,
                                        'stc_plot_%s.png' % session_id)
         pl.figure()
         pl.plot(o_ts, 'o-')
-        pl.hold('on')
+        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0"):
+            pl.hold('on')
         pl.plot(stc_ts, 's-')
         pl.legend(('original BOLD', 'ST corrected BOLD'))
         pl.title("session %s: STC QA for voxel (%s, %s, %s)" % (

--- a/pypreprocess/time_diff.py
+++ b/pypreprocess/time_diff.py
@@ -12,8 +12,10 @@ This has been implemented in the Nipy package.
 We give here a simpler implementation with modified dependences
 
 '''
+import matplotlib
 import numpy as np
 import nibabel as nib
+from distutils.version import LooseVersion
 from nilearn.plotting import plot_stat_map
 from nilearn.image.image import check_niimg_4d
 from nilearn.image import mean_img, reorder_img
@@ -230,11 +232,13 @@ def plot_tsdiffs(results, use_same_figure=True):
 
     # slice plots min max mean
     ax = next(iter_axes)
-    ax.hold(True)
+    if LooseVersion(matplotlib.__version__) < LooseVersion("2.0"):
+        ax.hold(True)
     ax.plot(np.mean(scaled_slice_diff, 0), 'k')
     ax.plot(np.min(scaled_slice_diff, 0), 'b')
     ax.plot(np.max(scaled_slice_diff, 0), 'r')
-    ax.hold(False)
+    if LooseVersion(matplotlib.__version__) < LooseVersion("2.0"):
+        ax.hold(False)
     xmax_labels(ax, S + 1, 'Slice number',
                 'Max/mean/min \n slice variation')
 


### PR DESCRIPTION
As referenced in #317 , some tests are failing due to deprecated matplotlib attributes. This should take care of that. CircleCI tests should fail, but this PR is supposed to take care of that.