### PR TITLE
[MRG] Restored default value for write_bounding_box

### DIFF
--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -854,7 +854,7 @@ def _do_subject_normalize(subject_data, fwhm=0., anat_fwhm=0., caching=True,
                 parameter_file=parameter_file,
                 apply_to_files=apply_to_files,
                 write_voxel_sizes=list(write_voxel_sizes),
-                write_bounding_box=write_bounding_box,
+                write_bounding_box=[[-78, -112, -50], [78, 76, 85]],
                 write_interp=1, jobtype='write',
                 interface_kwargs=kwargs))
 


### PR DESCRIPTION
Restored the previous value for the write_bounding_box parameter, as mentioned in #312 

Since it seems to be a fixed value, I could also add a keyword argument to do_subject_normalize and put this default value there, so is easily accesible in case it needs change.

