### PR TITLE
Import from joblib directly

### DIFF
--- a/examples/pure_python/coreg_demos.py
+++ b/examples/pure_python/coreg_demos.py
@@ -13,7 +13,7 @@ from pypreprocess.datasets import fetch_spm_auditory
 from nilearn.datasets import fetch_nyu_rest
 from pypreprocess.reporting.check_preprocessing import plot_registration
 from pypreprocess.coreg import Coregister
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 
 # misc
 mem = Memory("demos_cache")

--- a/examples/pure_python/realign_demos.py
+++ b/examples/pure_python/realign_demos.py
@@ -8,7 +8,7 @@ import sys
 from tempfile import mkdtemp
 from collections import namedtuple
 import matplotlib.pyplot as plt
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from pypreprocess.realign import MRIMotionCorrection
 from pypreprocess.reporting.check_preprocessing import (
     plot_spm_motion_parameters)

--- a/pypreprocess/external/nistats/glm.py
+++ b/pypreprocess/external/nistats/glm.py
@@ -22,7 +22,7 @@ import pandas as pd
 from nibabel import load, Nifti1Image
 
 from sklearn.base import BaseEstimator, TransformerMixin, clone
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from nilearn._utils import CacheMixin
 from nilearn._utils.class_inspect import get_params
 from nilearn.input_data import NiftiMasker

--- a/pypreprocess/io_utils.py
+++ b/pypreprocess/io_utils.py
@@ -13,7 +13,7 @@ import tempfile
 import filecmp
 import numpy as np
 import nibabel
-from sklearn.externals import joblib
+import joblib
 from nipype.interfaces.dcm2nii import Dcm2nii
 from nipype.caching import Memory
 from nilearn.image import iter_img

--- a/pypreprocess/nipype_preproc_fsl_utils.py
+++ b/pypreprocess/nipype_preproc_fsl_utils.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import nipype.interfaces.fsl as fsl
 from nipype.caching import Memory as NipypeMemory
-from sklearn.externals.joblib import Memory  as JoblibMemory
+from joblib import Memory  as JoblibMemory
 from nilearn._utils.compat import _basestring
 
 fsl.FSLCommand.set_default_output_type('NIFTI_GZ')

--- a/pypreprocess/nipype_preproc_spm_utils.py
+++ b/pypreprocess/nipype_preproc_spm_utils.py
@@ -19,7 +19,7 @@ from .slice_timing import get_slice_indices
 from .conf_parser import _generate_preproc_pipeline
 import matplotlib
 matplotlib.use('Agg')
-from sklearn.externals.joblib import Parallel, delayed, Memory as JoblibMemory
+from joblib import Parallel, delayed, Memory as JoblibMemory
 from nilearn._utils.compat import _basestring
 import nipype.interfaces.spm as spm
 from nipype.caching import Memory as NipypeMemory

--- a/pypreprocess/purepython_preproc_utils.py
+++ b/pypreprocess/purepython_preproc_utils.py
@@ -10,7 +10,7 @@ import os
 import inspect
 from .reporting.preproc_reporter import (
     generate_preproc_undergone_docstring)
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from nilearn._utils.compat import _basestring
 from .io_utils import get_basenames, save_vols, is_niimg, load_vols
 from .subject_data import SubjectData

--- a/pypreprocess/realign.py
+++ b/pypreprocess/realign.py
@@ -11,7 +11,7 @@ import scipy.ndimage as ndimage
 import scipy.linalg
 import nibabel
 from nilearn._utils.compat import _basestring
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from .kernel_smooth import smooth_image
 from .affine_transformations import (
     get_initial_motion_params, transform_coords, apply_realignment_to_vol,

--- a/pypreprocess/reporting/preproc_reporter.py
+++ b/pypreprocess/reporting/preproc_reporter.py
@@ -18,7 +18,7 @@ import pylab as pl
 import nibabel
 from distutils.version import LooseVersion
 from nilearn._utils.compat import _basestring
-from sklearn.externals import joblib
+import joblib
 from .check_preprocessing import (plot_registration,
                                   plot_segmentation,
                                   plot_spm_motion_parameters)

--- a/pypreprocess/spm_loader/utils.py
+++ b/pypreprocess/spm_loader/utils.py
@@ -3,7 +3,7 @@ import sys
 import re
 import time
 import json
-from sklearn.externals import joblib
+import joblib
 import multiprocessing
 
 import nibabel as nb

--- a/pypreprocess/subject_data.py
+++ b/pypreprocess/subject_data.py
@@ -12,7 +12,7 @@ import time
 import warnings
 import numpy as np
 from matplotlib.pyplot import cm
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from nilearn._utils.compat import _basestring
 from .io_utils import (niigz2nii as do_niigz2nii, dcm2nii as do_dcm2nii,
                        nii2niigz as do_nii2niigz,

--- a/scripts/abide_preproc.py
+++ b/scripts/abide_preproc.py
@@ -162,7 +162,7 @@ if len(sys.argv) > 3:
     INSTITUTES = sys.argv[3].split(",")
 
 if DO_DARTEL:
-    from sklearn.externals import joblib
+    import joblib
     joblib.Parallel(n_jobs=1, verbose=100)(
         joblib.delayed(preproc_abide_institute)(
             institute_id,

--- a/scripts/hcp_preproc_and_analysis.py
+++ b/scripts/hcp_preproc_and_analysis.py
@@ -28,7 +28,7 @@ from pypreprocess.reporting.base_reporter import (ProgressReport,
                                                   pretty_time
                                                   )
 from pypreprocess.conf_parser import _generate_preproc_pipeline
-from sklearn.externals.joblib import Parallel, delayed, Memory
+from joblib import Parallel, delayed, Memory
 from nipype.caching import Memory as NipypeMemory
 import nipype.interfaces.spm as spm
 from pypreprocess.io_utils import hard_link

--- a/scripts/openfmri.py
+++ b/scripts/openfmri.py
@@ -3,7 +3,7 @@ import glob
 import numpy as np
 import pandas as pd
 import nibabel
-from sklearn.externals.joblib import Parallel, delayed, Memory
+from joblib import Parallel, delayed, Memory
 from nistats.design_matrix import (make_design_matrix, check_design_matrix)
 from pypreprocess.external.nistats.glm import FMRILinearModel
 from pypreprocess.reporting.base_reporter import ProgressReport

--- a/spike/glm_utils.py
+++ b/spike/glm_utils.py
@@ -23,7 +23,7 @@ from nipy.modalities.fmri.experimental_paradigm import BlockParadigm
 from nipy.modalities.fmri.glm import FMRILinearModel
 from pypreprocess.datasets import fetch_spm_multimodal_fmri
 from pypreprocess.purepython_preproc_utils import do_subject_preproc
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from pypreprocess.reslice import reslice_vols
 
 

--- a/spike/sprint.py
+++ b/spike/sprint.py
@@ -8,7 +8,7 @@ from nipy.modalities.fmri.experimental_paradigm import BlockParadigm
 from nipy.modalities.fmri.glm import FMRILinearModel
 from pypreprocess.datasets import fetch_spm_multimodal_fmri
 from pypreprocess.purepython_preproc_utils import do_subject_preproc
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from pypreprocess.reslice import reslice_vols
 
 


### PR DESCRIPTION
scikit-learn has already made the contained joblib deprecated and simply return the one installed. They will further remove that package completely in 0.23. [link](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/externals/joblib/__init__.py)