### PR TITLE
cgi.escape deprecated from Python 3.2+

### DIFF
--- a/pypreprocess/external/tempita/_tempita.py
+++ b/pypreprocess/external/tempita/_tempita.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import re
 import sys
 import cgi
+from html import escape
 try:
     from urllib import quote as url_quote
 except ImportError:  # Py3
@@ -440,10 +441,10 @@ def html_quote(value, force=True):
     if not isinstance(value, basestring_):
         value = coerce_text(value)
     if sys.version >= "3" and isinstance(value, bytes):
-        value = cgi.escape(value.decode('latin1'), 1)
+        value = escape(value.decode('latin1'), 1)
         value = value.encode('latin1')
     else:
-        value = cgi.escape(value, 1)
+        value = escape(value, 1)
     if sys.version < "3":
         if is_unicode(value):
             value = value.encode('ascii', 'xmlcharrefreplace')


### PR DESCRIPTION
html.escape should be used instead.