### PR TITLE
Provide odd length kernels

### DIFF
--- a/pypreprocess/coreg.py
+++ b/pypreprocess/coreg.py
@@ -60,10 +60,14 @@ def compute_similarity_from_jhist(jh, fwhm=None, cost_fun='nmi'):
     krn1 = centered_smoothing_kernel(fwhm[0],
                                      np.linspace(-1 * lim[0], lim[0],
                                                  num=2 * lim[0]))
+    # Pad with zero to get odd length
+    krn1 = np.append(krn1,0)
     krn1 = krn1 / np.sum(krn1)
     krn2 = centered_smoothing_kernel(fwhm[1],
                                      np.linspace(-1 * lim[1], lim[1],
                                                  num=2 * lim[1]))
+    # Pad with zero to get odd length
+    krn2 = np.append(krn2,0)
     krn2 = krn2 / np.sum(krn2)
 
     # smooth the histogram with kern1 x kern2

--- a/pypreprocess/coreg.py
+++ b/pypreprocess/coreg.py
@@ -61,13 +61,13 @@ def compute_similarity_from_jhist(jh, fwhm=None, cost_fun='nmi'):
                                      np.linspace(-1 * lim[0], lim[0],
                                                  num=2 * lim[0]))
     # Pad with zero to get odd length
-    krn1 = np.append(krn1,0)
+    krn1 = np.append(krn1, 0)
     krn1 = krn1 / np.sum(krn1)
     krn2 = centered_smoothing_kernel(fwhm[1],
                                      np.linspace(-1 * lim[1], lim[1],
                                                  num=2 * lim[1]))
     # Pad with zero to get odd length
-    krn2 = np.append(krn2,0)
+    krn2 = np.append(krn2, 0)
     krn2 = krn2 / np.sum(krn2)
 
     # smooth the histogram with kern1 x kern2

--- a/pypreprocess/io_utils.py
+++ b/pypreprocess/io_utils.py
@@ -261,7 +261,11 @@ def is_3D(image):
     """Check whether image is 3D"""
 
     if isinstance(image, str):
-        image = nibabel.load(image)
+        if os.path.exists(image):
+            image = nibabel.load(image)
+        else:
+            raise FileNotFoundError("File {} not found.".format(
+                image))
     elif isinstance(image, list):
         image = nibabel.concat_images(image,
                                       check_affines=False


### PR DESCRIPTION
In release 1.6 of Scipy, the function `sepfir2d` only accepts odd length arrays for `hrow` and `hcol` (see this [PR](https://github.com/scipy/scipy/pull/12703)).