### PR TITLE
initial commit: test run on haxby dataset

### DIFF
--- a/pypreprocess/tests/test_reporting.py
+++ b/pypreprocess/tests/test_reporting.py
@@ -1,0 +1,27 @@
+import os
+from nilearn.datasets import fetch_haxby
+from pypreprocess.nipype_preproc_spm_utils import (do_subjects_preproc,
+                                                    SubjectData)
+
+def test_reporting():
+    # fetch HAXBY dataset
+    haxby_data = fetch_haxby(subjects=1)
+
+    # set output dir
+    output_dir = os.path.join(os.path.dirname(haxby_data.mask),"haxby_runs")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    # instantiate subject_data object
+    subject_data = SubjectData()
+    subject_data.subject_id = 'subj1'
+    subject_data.session_id = "haxby2001"
+
+    # set func
+    subject_data.func = haxby_data.func[0]
+    subject_data.anat = haxby_data.anat[0]
+    subject_data.output_dir = os.path.join(output_dir,subject_data.subject_id)
+
+    # do preprocessing proper
+    result = do_subjects_preproc([subject_data],output_dir=output_dir,
+                                    dataset_id="HAXBY 2001",report=True)

--- a/pypreprocess/tests/test_reporting.py
+++ b/pypreprocess/tests/test_reporting.py
@@ -8,7 +8,7 @@ def test_reporting():
     haxby_data = fetch_haxby(subjects=1)
 
     # set output dir
-    output_dir = os.path.join(os.path.dirname(haxby_data.mask),"haxby_runs")
+    output_dir = os.path.join(os.path.dirname(haxby_data.mask), "haxby_runs")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 


### PR DESCRIPTION
For testing the new version of reporting on Travis CI, I have created a shorter version of the [Haxby example](https://github.com/neurospin/pypreprocess/blob/7ad460d4e0985e261536b4c95dfc805d03f3c70f/examples/easy_start/nipype_preproc_spm_haxby.py) that runs all the preprocessing steps on just one of the subjects and then creates a report for this. But the problem here is that a complete run of pypreprocess would require SPM and MATLAB installation which does not happen during Travis runs. 

Let me know if I have misunderstood what you were asking for, @bthirion.

Thanks!